### PR TITLE
Allow offspec query params

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.43
+          version: v1.47

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.13', '1.14', '1.15', '1.16', '1.17' ]
+        go: [ '1.13', '1.14', '1.15', '1.16', '1.17', '1.18' ]
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Editors
 .vscode/
+.idea/

--- a/simple_url.go
+++ b/simple_url.go
@@ -26,6 +26,8 @@ type SimpleURL struct {
 	PageSize     uint
 	PageNumber   uint
 	Include      []string
+	// Params contains all off-spec query parameters.
+	Params map[string][]string
 }
 
 // NewSimpleURL takes and parses a *url.URL and returns a SimpleURL.
@@ -38,6 +40,7 @@ func NewSimpleURL(u *url.URL) (SimpleURL, error) {
 		Filter:       nil,
 		SortingRules: []string{},
 		Include:      []string{},
+		Params:       map[string][]string{},
 	}
 
 	if u == nil {
@@ -102,8 +105,7 @@ func NewSimpleURL(u *url.URL) (SimpleURL, error) {
 					sURL.Include = append(sURL.Include, parseCommaList(include)...)
 				}
 			default:
-				// Unkmown parameter
-				return sURL, NewErrUnknownParameter(name)
+				sURL.Params[name] = values[name]
 			}
 		}
 	}

--- a/simple_url_test.go
+++ b/simple_url_test.go
@@ -42,6 +42,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{},
 			},
 			expectedError: nil,
 		}, {
@@ -59,6 +60,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{},
 			},
 			expectedError: nil,
 		}, {
@@ -76,6 +78,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{},
 			},
 			expectedError: nil,
 		}, {
@@ -93,6 +96,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{},
 			},
 			expectedError: nil,
 		}, {
@@ -110,6 +114,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{},
 			},
 			expectedError: nil,
 		}, {
@@ -140,6 +145,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     20,
 				PageNumber:   1,
 				Include:      []string{"type2.type3", "type4"},
+				Params:       map[string][]string{},
 			},
 			expectedError: nil,
 		}, {
@@ -159,6 +165,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{},
 			},
 			expectedError: nil,
 		}, {
@@ -177,6 +184,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{},
 			},
 			expectedError: NewErrInvalidPageSizeParameter("-1"),
 		}, {
@@ -195,6 +203,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{},
 			},
 			expectedError: NewErrInvalidPageNumberParameter("-1"),
 		}, {
@@ -213,8 +222,8 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{"unknownparam": {"somevalue"}},
 			},
-			expectedError: NewErrUnknownParameter("unknownparam"),
 		}, {
 			name: "filter query",
 			url: `
@@ -239,6 +248,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{},
 			},
 			expectedError: nil,
 		}, {
@@ -257,6 +267,7 @@ func TestSimpleURL(t *testing.T) {
 				PageSize:     0,
 				PageNumber:   0,
 				Include:      []string{},
+				Params:       map[string][]string{},
 			},
 			expectedError: NewErrMalformedFilterParameter(`{"thisis:invalid"}`),
 		},


### PR DESCRIPTION
This PR allows query parameters that are not specified in the `JSON:API` specification and previously caused a `400 Bad Request` error.