### PR TITLE
Allow complex data structures

### DIFF
--- a/document_test.go
+++ b/document_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"math"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -111,6 +112,8 @@ func TestMarshalDocument(t *testing.T) {
 		Uint16:   1016,
 		Uint32:   1032,
 		Uint64:   1064,
+		Float32:  math.MaxFloat32,
+		Float64:  math.MaxFloat64,
 		Bool:     true,
 		Time:     getTime(),
 		Bytes:    []byte{1, 2, 3},
@@ -157,19 +160,22 @@ func TestMarshalDocument(t *testing.T) {
 	)
 
 	cres1 := Wrap(mockType4{
-		ID:       "id1",
-		StrArr:   strarr,
-		Int8Arr:  int8arr,
-		Int32Arr: int32arr,
-		Uint8Arr: bytearr,
-		BoolArr:  boolarr,
+		ID:         "id1",
+		StrArr:     strarr,
+		Int8Arr:    int8arr,
+		Int32Arr:   int32arr,
+		Uint8Arr:   bytearr,
+		BoolArr:    boolarr,
+		Float32Arr: []float32{math.MaxFloat32},
+		Float64Arr: []float64{math.MaxFloat64},
 	})
 
 	cres2 := Wrap(mockType5{
-		ID:         "id1",
-		StrArrPtr:  &strarr,
-		Int8ArrPtr: &int8arr,
-		BoolArrPtr: &boolarr,
+		ID:            "id1",
+		StrArrPtr:     &strarr,
+		Int8ArrPtr:    &int8arr,
+		BoolArrPtr:    &boolarr,
+		Float32ArrPtr: &[]float32{3.4028235e+38},
 	})
 
 	// uint8
@@ -259,7 +265,7 @@ func TestMarshalDocument(t *testing.T) {
 				},
 			},
 			fields: map[string][]string{
-				"mocktype": {"str", "uint64", "bool", "int", "time", "bytes", "to-1", "to-x-from-1"},
+				"mocktype": {"str", "uint64", "bool", "int", "time", "bytes", "float32", "float64", "to-1", "to-x-from-1"},
 			},
 		}, {
 			name: "resource array attributes",
@@ -267,7 +273,7 @@ func TestMarshalDocument(t *testing.T) {
 				Data: cres1,
 			},
 			fields: map[string][]string{
-				"mocktype4": {"strarr", "int8arr", "int32arr", "uint8arr", "boolarr", "int16arr"},
+				"mocktype4": {"strarr", "int8arr", "int32arr", "uint8arr", "boolarr", "int16arr", "float32arr", "float64arr"},
 			},
 		}, {
 			name: "resource nullable array attributes",
@@ -275,7 +281,7 @@ func TestMarshalDocument(t *testing.T) {
 				Data: cres2,
 			},
 			fields: map[string][]string{
-				"mocktype5": {"strarrptr", "int8arrptr", "int32arrptr", "uint8arrptr", "boolarrptr", "int16arrptr"},
+				"mocktype5": {"strarrptr", "int8arrptr", "int32arrptr", "uint8arrptr", "boolarrptr", "int16arrptr", "float32arrptr", "float64arrptr"},
 			},
 		}, {
 			name: "resource bytes",
@@ -541,6 +547,8 @@ func TestUnmarshalDocument(t *testing.T) {
 		Uint16:   1016,
 		Uint32:   1032,
 		Uint64:   1064,
+		Float32:  math.MaxFloat32,
+		Float64:  math.MaxFloat64,
 		Bool:     true,
 		Time:     getTime(),
 		Bytes:    []byte{1, 2, 3},
@@ -652,7 +660,7 @@ func TestUnmarshalDocument(t *testing.T) {
 
 		col2, ok := doc.Data.(Collection)
 		assert.True(ok)
-		
+
 		// A few assertions to make sure some edge cases work.
 		arrRes := col2.At(5)
 		assert.Equal("uint8arrtest", arrRes.GetType().Name)

--- a/document_test.go
+++ b/document_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"math"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -163,6 +164,10 @@ func TestMarshalDocument(t *testing.T) {
 			Prop2: "mno",
 			Prop3: "pqr",
 		},
+		Float32Matrix: [][]float32{
+			{1.0, 0.5, 0.25, 0.175},
+			{0.175, 0.25, 0.5, 1.0},
+		},
 	}))
 
 	var (
@@ -269,6 +274,12 @@ func TestMarshalDocument(t *testing.T) {
 				Nullable:    true,
 				Unmarshaler: testObjType{},
 			},
+			"float32MatrixArr": {
+				Name:        "float32MatrixArr",
+				Type:        AttrTypeOther,
+				Array:       true,
+				Unmarshaler: ReflectTypeUnmarshaler{Type: reflect.TypeOf([][]float32{})},
+			},
 		},
 	}}
 	cres4.SetID("id1")
@@ -290,6 +301,14 @@ func TestMarshalDocument(t *testing.T) {
 		},
 	})
 	cres4.Set("objptr", nil)
+	cres4.Set("float32MatrixArr", [][][]float32{
+		{
+			{0.1, 0.2, 0.3, 0.4, 0.5},
+		},
+		{
+			{0.6, 0.7, 0.8, 0.9, 1.0},
+		},
+	})
 
 	// Test struct
 	tests := []struct {
@@ -392,7 +411,7 @@ func TestMarshalDocument(t *testing.T) {
 				Data: cres4,
 			},
 			fields: map[string][]string{
-				"objtest": {"obj", "objarr", "objptr", "objptrarr"},
+				"objtest": {"obj", "objarr", "objptr", "objptrarr", "float32MatrixArr"},
 			},
 		}, {
 			name: "collection",
@@ -406,7 +425,7 @@ func TestMarshalDocument(t *testing.T) {
 			fields: map[string][]string{
 				"mocktype":   {"str", "uint64", "bool", "int", "time", "to-1", "to-x-from-1"},
 				"mocktypes1": {"str"},
-				"mocktype6":  {"obj", "objPtr", "objArr"},
+				"mocktype6":  {"obj", "objPtr", "objArr", "float32Matrix"},
 			},
 		}, {
 			name: "meta",

--- a/document_test.go
+++ b/document_test.go
@@ -151,6 +151,20 @@ func TestMarshalDocument(t *testing.T) {
 		Str: "str with <html> chars",
 	}))
 
+	col.Add(Wrap(&mockType6{
+		ID: "test-123",
+		Obj: testObjType{
+			Prop1: "abc",
+			Prop2: "def",
+			Prop3: "ghi",
+		},
+		ObjPtr: &testObjType{
+			Prop1: "jkl",
+			Prop2: "mno",
+			Prop3: "pqr",
+		},
+	}))
+
 	var (
 		strarr   = []string{"foo", "bar", "baz"}
 		int8arr  = []int8{-100, -50, 0, 50, 100}
@@ -392,6 +406,7 @@ func TestMarshalDocument(t *testing.T) {
 			fields: map[string][]string{
 				"mocktype":   {"str", "uint64", "bool", "int", "time", "to-1", "to-x-from-1"},
 				"mocktypes1": {"str"},
+				"mocktype6":  {"obj", "objPtr", "objArr"},
 			},
 		}, {
 			name: "meta",
@@ -749,6 +764,24 @@ func TestUnmarshalDocument(t *testing.T) {
 	})
 	col.Add(Wrap(r4))
 
+	r6 := Wrap(&mockType6{
+		ID: "test-123",
+		Obj: testObjType{
+			Prop1: "abc",
+			Prop2: "def",
+			Prop3: "ghi",
+		},
+		ObjPtr: &testObjType{
+			Prop1: "jkl",
+			Prop2: "mno",
+			Prop3: "pqr",
+		},
+	})
+	col.Add(r6)
+	typ6 := r6.GetType()
+
+	_ = schema.AddType(typ6)
+
 	// Tests
 	t.Run("resource with inclusions", func(t *testing.T) {
 		assert := assert.New(t)
@@ -793,6 +826,7 @@ func TestUnmarshalDocument(t *testing.T) {
 		url, _ := NewURLFromRaw(schema, "/mocktype/id1")
 		url.Params.Fields["mocktype4"] = typ4.Fields()
 		url.Params.Fields["mocktype5"] = typ5.Fields()
+		url.Params.Fields["mocktype6"] = typ6.Fields()
 		url.Params.Fields["uint8arrtest"] = uint8arrRes.Type.Fields()
 
 		doc := &Document{

--- a/document_test.go
+++ b/document_test.go
@@ -226,6 +226,7 @@ func TestMarshalDocument(t *testing.T) {
 	}}
 
 	arr := []uint8{1, 2, 4, 8, 16, 32}
+
 	cres3.SetID("id1")
 	cres3.Set("uint8arr", arr)
 	cres3.Set("uint8arrptr", &arr)
@@ -265,7 +266,18 @@ func TestMarshalDocument(t *testing.T) {
 				},
 			},
 			fields: map[string][]string{
-				"mocktype": {"str", "uint64", "bool", "int", "time", "bytes", "float32", "float64", "to-1", "to-x-from-1"},
+				"mocktype": {
+					"str",
+					"uint64",
+					"bool",
+					"int",
+					"time",
+					"bytes",
+					"float32",
+					"float64",
+					"to-1",
+					"to-x-from-1",
+				},
 			},
 		}, {
 			name: "resource array attributes",
@@ -273,7 +285,16 @@ func TestMarshalDocument(t *testing.T) {
 				Data: cres1,
 			},
 			fields: map[string][]string{
-				"mocktype4": {"strarr", "int8arr", "int32arr", "uint8arr", "boolarr", "int16arr", "float32arr", "float64arr"},
+				"mocktype4": {
+					"strarr",
+					"int8arr",
+					"int32arr",
+					"uint8arr",
+					"boolarr",
+					"int16arr",
+					"float32arr",
+					"float64arr",
+				},
 			},
 		}, {
 			name: "resource nullable array attributes",
@@ -281,7 +302,16 @@ func TestMarshalDocument(t *testing.T) {
 				Data: cres2,
 			},
 			fields: map[string][]string{
-				"mocktype5": {"strarrptr", "int8arrptr", "int32arrptr", "uint8arrptr", "boolarrptr", "int16arrptr", "float32arrptr", "float64arrptr"},
+				"mocktype5": {
+					"strarrptr",
+					"int8arrptr",
+					"int32arrptr",
+					"uint8arrptr",
+					"boolarrptr",
+					"int16arrptr",
+					"float32arrptr",
+					"float64arrptr",
+				},
 			},
 		}, {
 			name: "resource bytes",
@@ -289,7 +319,16 @@ func TestMarshalDocument(t *testing.T) {
 				Data: cres3,
 			},
 			fields: map[string][]string{
-				"bytestest": {"uint8arr", "uint8arrptr", "bytes", "bytesptr", "nullbytes", "nullbytesptr", "uint8arrempty", "uint8arrptrnull"},
+				"bytestest": {
+					"uint8arr",
+					"uint8arrptr",
+					"bytes",
+					"bytesptr",
+					"nullbytes",
+					"nullbytesptr",
+					"uint8arrempty",
+					"uint8arrptrnull",
+				},
 			},
 		}, {
 			name: "collection",
@@ -582,7 +621,7 @@ func TestUnmarshalDocument(t *testing.T) {
 		},
 	})
 
-	schema.AddType(*uint8arrRes.Type)
+	_ = schema.AddType(*uint8arrRes.Type)
 
 	uint8arrRes.SetID("id1")
 	uint8arrRes.Set("uint8arr", []uint8{0, 1, 2, 4, 8, 16, 32, 64, 128, 255})

--- a/document_test.go
+++ b/document_test.go
@@ -148,6 +148,30 @@ func TestMarshalDocument(t *testing.T) {
 		Str: "str with <html> chars",
 	}))
 
+	var (
+		strarr   = []string{"foo", "bar", "baz"}
+		int8arr  = []int8{-100, -50, 0, 50, 100}
+		int32arr = []int32{-10000000, 123456, -45, 333333333}
+		bytearr  = []byte("hello world")
+		boolarr  = []bool{true, false, true, true}
+	)
+
+	cres1 := Wrap(mockType4{
+		ID:       "id1",
+		StrArr:   strarr,
+		Int8Arr:  int8arr,
+		Int32Arr: int32arr,
+		Uint8Arr: bytearr,
+		BoolArr:  boolarr,
+	})
+
+	cres2 := Wrap(mockType5{
+		ID:         "id1",
+		StrArrPtr:  &strarr,
+		Int8ArrPtr: &int8arr,
+		BoolArrPtr: &boolarr,
+	})
+
 	// Test struct
 	tests := []struct {
 		name   string
@@ -180,6 +204,22 @@ func TestMarshalDocument(t *testing.T) {
 			},
 			fields: map[string][]string{
 				"mocktype": {"str", "uint64", "bool", "int", "time", "bytes", "to-1", "to-x-from-1"},
+			},
+		}, {
+			name: "resource array attributes",
+			doc: &Document{
+				Data: cres1,
+			},
+			fields: map[string][]string{
+				"mocktype4": {"strarr", "int8arr", "int32arr", "uint8arr", "boolarr", "int16arr"},
+			},
+		}, {
+			name: "resource nullable array attributes",
+			doc: &Document{
+				Data: cres2,
+			},
+			fields: map[string][]string{
+				"mocktype5": {"strarrptr", "int8arrptr", "int32arrptr", "uint8arrptr", "boolarrptr", "int16arrptr"},
 			},
 		}, {
 			name: "collection",

--- a/error.go
+++ b/error.go
@@ -146,7 +146,8 @@ func NewErrInvalidPageSizeParameter(badPageSize string) Error {
 	return e
 }
 
-// NewErrInvalidFieldValueInBody (400) returns the corresponding error.
+// NewErrInvalidFieldValueInBody (400) returns the corresponding error. If typ is empty, it will
+// not be included in the metadata.
 func NewErrInvalidFieldValueInBody(field string, badValue string, typ string) Error {
 	e := NewError()
 
@@ -155,7 +156,10 @@ func NewErrInvalidFieldValueInBody(field string, badValue string, typ string) Er
 	e.Detail = "The field value is invalid for the expected type."
 	e.Meta["field"] = field
 	e.Meta["bad-value"] = badValue
-	e.Meta["type"] = typ
+
+	if typ != "" {
+		e.Meta["type"] = typ
+	}
 
 	return e
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -781,11 +781,12 @@ func TestFilterResource(t *testing.T) {
 
 	for _, test := range attrTests {
 		typ := &Type{Name: "type"}
-		ty, n := GetAttrType(fmt.Sprintf("%T", test.rval))
+		ty, a, n := GetAttrType(fmt.Sprintf("%T", test.rval))
 		typ.Attrs = map[string]Attr{
 			"attr": {
 				Name:     "attr",
 				Type:     ty,
+				Array:    a,
 				Nullable: n,
 			},
 		}
@@ -924,11 +925,12 @@ func TestFilterResource(t *testing.T) {
 
 		for j := range test.rvals {
 			attrName := "attr" + strconv.Itoa(j)
-			ty, n := GetAttrType(fmt.Sprintf("%T", test.rvals[j]))
+			ty, a, n := GetAttrType(fmt.Sprintf("%T", test.rvals[j]))
 			_ = typ.AddAttr(
 				Attr{
 					Name:     attrName,
 					Type:     ty,
+					Array:    a,
 					Nullable: n,
 				},
 			)

--- a/helpers.go
+++ b/helpers.go
@@ -133,10 +133,11 @@ func BuildType(v interface{}) (Type, error) {
 		apiTag := fs.Tag.Get("api")
 
 		if apiTag == "attr" {
-			fieldType, null := GetAttrType(fs.Type.String())
+			fieldType, arr, null := GetAttrType(fs.Type.String())
 			typ.Attrs[jsonTag] = Attr{
 				Name:     jsonTag,
 				Type:     fieldType,
+				Array:    arr,
 				Nullable: null,
 			}
 		}

--- a/helpers.go
+++ b/helpers.go
@@ -57,6 +57,9 @@ func Check(v interface{}) error {
 				"[]uint", "[]uint8", "[]uint16", "[]uint32", "[]uint64",
 				"*[]uint", "*[]uint8", "*[]uint16", "*[]uint32", "*[]uint64",
 
+				"float32", "*float32", "[]float32", "*[]float32",
+				"float64", "*float64", "[]float64", "*[]float64",
+
 				"string", "*string", "[]string", "*[]string",
 				"bool", "*bool", "[]bool", "*[]bool",
 				"time.Time", "*time.Time", "[]time.Time", "*[]time.Time":

--- a/helpers.go
+++ b/helpers.go
@@ -47,18 +47,19 @@ func Check(v interface{}) error {
 
 			switch sf.Type.String() {
 			case
-				"string",
 				"int", "int8", "int16", "int32", "int64",
-				"uint", "uint8", "uint16", "uint32", "uint64",
-				"bool",
-				"time.Time",
-				"[]uint8",
-				"*string",
 				"*int", "*int8", "*int16", "*int32", "*int64",
+				"[]int", "[]int8", "[]int16", "[]int32", "[]int64",
+				"*[]int", "*[]int8", "*[]int16", "*[]int32", "*[]int64",
+
+				"uint", "uint8", "uint16", "uint32", "uint64",
 				"*uint", "*uint8", "*uint16", "*uint32", "*uint64",
-				"*bool",
-				"*time.Time",
-				"*[]uint8":
+				"[]uint", "[]uint8", "[]uint16", "[]uint32", "[]uint64",
+				"*[]uint", "*[]uint8", "*[]uint16", "*[]uint32", "*[]uint64",
+
+				"string", "*string", "[]string", "*[]string",
+				"bool", "*bool", "[]bool", "*[]bool",
+				"time.Time", "*time.Time", "[]time.Time", "*[]time.Time":
 				isValid = true
 			}
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -64,6 +64,14 @@ func TestBuildType(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(true, Equal(Wrap(&mockType1{}), typ.New()))
 
+	typ, err = BuildType(&mockType4{})
+	assert.NoError(err)
+	assert.True(Equal(Wrap(&mockType4{}), typ.New()))
+
+	typ, err = BuildType(&mockType6{})
+	assert.NoError(err)
+	assert.True(Equal(Wrap(&mockType6{}), typ.New()))
+
 	// Build from invalid struct
 	_, err = BuildType(invalidRelAPITag{})
 	assert.Error(err)
@@ -76,6 +84,10 @@ func TestIDAndType(t *testing.T) {
 		ID: "abc123",
 	}
 	id, typ := IDAndType(mt)
+	assert.Equal("abc123", id)
+	assert.Equal("mocktype", typ)
+
+	id, typ = IDAndType(&mt)
 	assert.Equal("abc123", id)
 	assert.Equal("mocktype", typ)
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -34,6 +34,12 @@ func TestCheck(t *testing.T) {
 		err,
 		"jsonapi: relationship \"Rel\" of type \"typename\" is not string or []string",
 	)
+
+	err = Check(mockType4{})
+	assert.NoError(err)
+
+	err = Check(mockType5{})
+	assert.NoError(err)
 }
 
 func TestBuildType(t *testing.T) {

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -140,23 +140,26 @@ func (c stringTypeUnmarshalerRot13) GetZeroValue(array, nullable bool) interface
 }
 
 func (c stringTypeUnmarshalerRot13) UnmarshalToType(data []byte, array, nullable bool) (interface{}, error) {
-	var v interface{}
-	var err error
+	var (
+		v   interface{}
+		err error
+	)
 
 	rot13 := func(r rune) rune {
 		if r >= 'a' && r <= 'z' {
 			if r >= 'm' {
 				return r - 13
-			} else {
-				return r + 13
 			}
+
+			return r + 13
 		} else if r >= 'A' && r <= 'Z' {
 			if r >= 'M' {
 				return r - 13
-			} else {
-				return r + 13
 			}
+
+			return r + 13
 		}
+
 		return r
 	}
 
@@ -187,4 +190,3 @@ func (c stringTypeUnmarshalerRot13) UnmarshalToType(data []byte, array, nullable
 
 	return v, err
 }
-

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -34,7 +34,7 @@ type mocktype struct {
 	Uint64 uint64    `json:"uint64" api:"attr"`
 	Bool   bool      `json:"bool" api:"attr"`
 	Time   time.Time `json:"time" api:"attr"`
-	Bytes  []byte    `json:"bytes" api:"attr"`
+	Bytes  []byte    `json:"bytes" api:"attr" bytes:"true"`
 
 	// Relationships
 	To1      string   `json:"to-1" api:"rel,mocktype"`

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -21,20 +21,22 @@ type mocktype struct {
 	ID string `json:"id" api:"mocktype"`
 
 	// Attributes
-	Str    string    `json:"str" api:"attr"`
-	Int    int       `json:"int" api:"attr"`
-	Int8   int8      `json:"int8" api:"attr"`
-	Int16  int16     `json:"int16" api:"attr"`
-	Int32  int32     `json:"int32" api:"attr"`
-	Int64  int64     `json:"int64" api:"attr"`
-	Uint   uint      `json:"uint" api:"attr"`
-	Uint8  uint8     `json:"uint8" api:"attr"`
-	Uint16 uint16    `json:"uint16" api:"attr"`
-	Uint32 uint32    `json:"uint32" api:"attr"`
-	Uint64 uint64    `json:"uint64" api:"attr"`
-	Bool   bool      `json:"bool" api:"attr"`
-	Time   time.Time `json:"time" api:"attr"`
-	Bytes  []byte    `json:"bytes" api:"attr" bytes:"true"`
+	Str     string    `json:"str" api:"attr"`
+	Int     int       `json:"int" api:"attr"`
+	Int8    int8      `json:"int8" api:"attr"`
+	Int16   int16     `json:"int16" api:"attr"`
+	Int32   int32     `json:"int32" api:"attr"`
+	Int64   int64     `json:"int64" api:"attr"`
+	Uint    uint      `json:"uint" api:"attr"`
+	Uint8   uint8     `json:"uint8" api:"attr"`
+	Uint16  uint16    `json:"uint16" api:"attr"`
+	Uint32  uint32    `json:"uint32" api:"attr"`
+	Uint64  uint64    `json:"uint64" api:"attr"`
+	Float32 float32   `json:"float32" api:"attr"`
+	Float64 float64   `json:"float64" api:"attr"`
+	Bool    bool      `json:"bool" api:"attr"`
+	Time    time.Time `json:"time" api:"attr"`
+	Bytes   []byte    `json:"bytes" api:"attr" bytes:"true"`
 
 	// Relationships
 	To1      string   `json:"to-1" api:"rel,mocktype"`

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -3,7 +3,6 @@ package jsonapi_test
 import (
 	"encoding/json"
 	"flag"
-	"strings"
 	"time"
 
 	. "github.com/mfcochauxlaberge/jsonapi"
@@ -81,24 +80,6 @@ func (t testObjType) GetZeroValue(array, nullable bool) interface{} {
 	default:
 		return testObjType{}
 	}
-}
-
-func (t testObjType) CheckAttrType(typ string) (ok, array, nullable bool) {
-	bi := strings.Index(typ, "[]")
-	array = bi == 0 || bi == 1
-	nullable = strings.HasPrefix(typ, "*")
-
-	switch {
-	case nullable && array:
-		typ = typ[3:]
-	case array:
-		typ = typ[2:]
-	case nullable:
-		typ = typ[1:]
-	}
-
-	// %T includes the package name for any non-builtin type.
-	return typ == "jsonapi_test.testObjType", array, nullable
 }
 
 func (t testObjType) UnmarshalToType(data []byte, array, nullable bool) (interface{}, error) {

--- a/mock_schema_test.go
+++ b/mock_schema_test.go
@@ -112,7 +112,7 @@ type mockType4 struct {
 	Int32Arr  []int32     `json:"int32arr" api:"attr"`
 	Int64Arr  []int64     `json:"int64arr" api:"attr"`
 	UintArr   []uint      `json:"uintarr" api:"attr"`
-	Uint8Arr  []uint8     `json:"uint8arr" api:"attr"`
+	Uint8Arr  []uint8     `json:"uint8arr" api:"attr" bytes:"true"`
 	Uint16Arr []uint16    `json:"uint16arr" api:"attr"`
 	Uint32Arr []uint32    `json:"uint32arr" api:"attr"`
 	Uint64Arr []uint64    `json:"uint64arr" api:"attr"`
@@ -131,7 +131,7 @@ type mockType5 struct {
 	Int32ArrPtr  *[]int32     `json:"int32arrptr" api:"attr"`
 	Int64ArrPtr  *[]int64     `json:"int64arrptr" api:"attr"`
 	UintArrPtr   *[]uint      `json:"uintarrptr" api:"attr"`
-	Uint8ArrPtr  *[]uint8     `json:"uint8arrptr" api:"attr"`
+	Uint8ArrPtr  *[]uint8     `json:"uint8arrptr" api:"attr" bytes:"true"`
 	Uint16ArrPtr *[]uint16    `json:"uint16arrptr" api:"attr"`
 	Uint32ArrPtr *[]uint32    `json:"uint32arrptr" api:"attr"`
 	Uint64ArrPtr *[]uint64    `json:"uint64arrptr" api:"attr"`

--- a/mock_schema_test.go
+++ b/mock_schema_test.go
@@ -105,36 +105,40 @@ type mockType4 struct {
 	ID string `json:"id" api:"mocktype4"`
 
 	// Attributes
-	StrArr    []string    `json:"strarr" api:"attr"`
-	IntArr    []int       `json:"intarr" api:"attr"`
-	Int8Arr   []int8      `json:"int8arr" api:"attr"`
-	Int16Arr  []int16     `json:"int16arr" api:"attr"`
-	Int32Arr  []int32     `json:"int32arr" api:"attr"`
-	Int64Arr  []int64     `json:"int64arr" api:"attr"`
-	UintArr   []uint      `json:"uintarr" api:"attr"`
-	Uint8Arr  []uint8     `json:"uint8arr" api:"attr" bytes:"true"`
-	Uint16Arr []uint16    `json:"uint16arr" api:"attr"`
-	Uint32Arr []uint32    `json:"uint32arr" api:"attr"`
-	Uint64Arr []uint64    `json:"uint64arr" api:"attr"`
-	BoolArr   []bool      `json:"boolarr" api:"attr"`
-	TimeArr   []time.Time `json:"timearr" api:"attr"`
+	StrArr     []string    `json:"strarr" api:"attr"`
+	IntArr     []int       `json:"intarr" api:"attr"`
+	Int8Arr    []int8      `json:"int8arr" api:"attr"`
+	Int16Arr   []int16     `json:"int16arr" api:"attr"`
+	Int32Arr   []int32     `json:"int32arr" api:"attr"`
+	Int64Arr   []int64     `json:"int64arr" api:"attr"`
+	UintArr    []uint      `json:"uintarr" api:"attr"`
+	Uint8Arr   []uint8     `json:"uint8arr" api:"attr" bytes:"true"`
+	Uint16Arr  []uint16    `json:"uint16arr" api:"attr"`
+	Uint32Arr  []uint32    `json:"uint32arr" api:"attr"`
+	Uint64Arr  []uint64    `json:"uint64arr" api:"attr"`
+	Float32Arr []float32   `json:"float32arr" api:"attr"`
+	Float64Arr []float64   `json:"float64arr" api:"attr"`
+	BoolArr    []bool      `json:"boolarr" api:"attr"`
+	TimeArr    []time.Time `json:"timearr" api:"attr"`
 }
 
 type mockType5 struct {
 	ID string `json:"id" api:"mocktype5"`
 
 	// Attributes
-	StrArrPtr    *[]string    `json:"strarrptr" api:"attr"`
-	IntArrPtr    *[]int       `json:"intarrptr" api:"attr"`
-	Int8ArrPtr   *[]int8      `json:"int8arrptr" api:"attr"`
-	Int16ArrPtr  *[]int16     `json:"int16arrptr" api:"attr"`
-	Int32ArrPtr  *[]int32     `json:"int32arrptr" api:"attr"`
-	Int64ArrPtr  *[]int64     `json:"int64arrptr" api:"attr"`
-	UintArrPtr   *[]uint      `json:"uintarrptr" api:"attr"`
-	Uint8ArrPtr  *[]uint8     `json:"uint8arrptr" api:"attr" bytes:"true"`
-	Uint16ArrPtr *[]uint16    `json:"uint16arrptr" api:"attr"`
-	Uint32ArrPtr *[]uint32    `json:"uint32arrptr" api:"attr"`
-	Uint64ArrPtr *[]uint64    `json:"uint64arrptr" api:"attr"`
-	BoolArrPtr   *[]bool      `json:"boolarrptr" api:"attr"`
-	TimeArrPtr   *[]time.Time `json:"timearrptr" api:"attr"`
+	StrArrPtr     *[]string    `json:"strarrptr" api:"attr"`
+	IntArrPtr     *[]int       `json:"intarrptr" api:"attr"`
+	Int8ArrPtr    *[]int8      `json:"int8arrptr" api:"attr"`
+	Int16ArrPtr   *[]int16     `json:"int16arrptr" api:"attr"`
+	Int32ArrPtr   *[]int32     `json:"int32arrptr" api:"attr"`
+	Int64ArrPtr   *[]int64     `json:"int64arrptr" api:"attr"`
+	UintArrPtr    *[]uint      `json:"uintarrptr" api:"attr"`
+	Uint8ArrPtr   *[]uint8     `json:"uint8arrptr" api:"attr" bytes:"true"`
+	Uint16ArrPtr  *[]uint16    `json:"uint16arrptr" api:"attr"`
+	Uint32ArrPtr  *[]uint32    `json:"uint32arrptr" api:"attr"`
+	Uint64ArrPtr  *[]uint64    `json:"uint64arrptr" api:"attr"`
+	Float32ArrPtr *[]float32   `json:"float32arrptr" api:"attr"`
+	Float64ArrPtr *[]float64   `json:"float64arrptr" api:"attr"`
+	BoolArrPtr    *[]bool      `json:"boolarrptr" api:"attr"`
+	TimeArrPtr    *[]time.Time `json:"timearrptr" api:"attr"`
 }

--- a/mock_schema_test.go
+++ b/mock_schema_test.go
@@ -100,3 +100,41 @@ type mockType3 struct {
 	Rel1 string   `json:"rel1" api:"rel,mocktypes1"`
 	Rel2 []string `json:"rel2" api:"rel,mocktypes1"`
 }
+
+type mockType4 struct {
+	ID string `json:"id" api:"mocktype4"`
+
+	// Attributes
+	StrArr    []string    `json:"strarr" api:"attr"`
+	IntArr    []int       `json:"intarr" api:"attr"`
+	Int8Arr   []int8      `json:"int8arr" api:"attr"`
+	Int16Arr  []int16     `json:"int16arr" api:"attr"`
+	Int32Arr  []int32     `json:"int32arr" api:"attr"`
+	Int64Arr  []int64     `json:"int64arr" api:"attr"`
+	UintArr   []uint      `json:"uintarr" api:"attr"`
+	Uint8Arr  []uint8     `json:"uint8arr" api:"attr"`
+	Uint16Arr []uint16    `json:"uint16arr" api:"attr"`
+	Uint32Arr []uint32    `json:"uint32arr" api:"attr"`
+	Uint64Arr []uint64    `json:"uint64arr" api:"attr"`
+	BoolArr   []bool      `json:"boolarr" api:"attr"`
+	TimeArr   []time.Time `json:"timearr" api:"attr"`
+}
+
+type mockType5 struct {
+	ID string `json:"id" api:"mocktype5"`
+
+	// Attributes
+	StrArrPtr    *[]string    `json:"strarrptr" api:"attr"`
+	IntArrPtr    *[]int       `json:"intarrptr" api:"attr"`
+	Int8ArrPtr   *[]int8      `json:"int8arrptr" api:"attr"`
+	Int16ArrPtr  *[]int16     `json:"int16arrptr" api:"attr"`
+	Int32ArrPtr  *[]int32     `json:"int32arrptr" api:"attr"`
+	Int64ArrPtr  *[]int64     `json:"int64arrptr" api:"attr"`
+	UintArrPtr   *[]uint      `json:"uintarrptr" api:"attr"`
+	Uint8ArrPtr  *[]uint8     `json:"uint8arrptr" api:"attr"`
+	Uint16ArrPtr *[]uint16    `json:"uint16arrptr" api:"attr"`
+	Uint32ArrPtr *[]uint32    `json:"uint32arrptr" api:"attr"`
+	Uint64ArrPtr *[]uint64    `json:"uint64arrptr" api:"attr"`
+	BoolArrPtr   *[]bool      `json:"boolarrptr" api:"attr"`
+	TimeArrPtr   *[]time.Time `json:"timearrptr" api:"attr"`
+}

--- a/mock_schema_test.go
+++ b/mock_schema_test.go
@@ -142,3 +142,16 @@ type mockType5 struct {
 	BoolArrPtr    *[]bool      `json:"boolarrptr" api:"attr"`
 	TimeArrPtr    *[]time.Time `json:"timearrptr" api:"attr"`
 }
+
+type mockType6 struct {
+	ID string `json:"ID" api:"mocktype6"`
+
+	Str       string         `json:"str" api:"attr"`
+	StrPtr    *string        `json:"strPtr" api:"attr"`
+	StrArr    []string       `json:"strArr" api:"attr" array:"true"`
+	StrPtrArr *[]string      `json:"strPtrArr" api:"attr" array:"true"`
+	Obj       testObjType    `json:"obj" api:"attr"`
+	ObjPtr    *testObjType   `json:"objPtr" api:"attr"`
+	ObjArr    []testObjType  `json:"objArr" api:"attr" array:"true"`
+	ObjArrPtr *[]testObjType `json:"objArrPtr" api:"attr" array:"true"`
+}

--- a/mock_schema_test.go
+++ b/mock_schema_test.go
@@ -146,12 +146,13 @@ type mockType5 struct {
 type mockType6 struct {
 	ID string `json:"ID" api:"mocktype6"`
 
-	Str       string         `json:"str" api:"attr"`
-	StrPtr    *string        `json:"strPtr" api:"attr"`
-	StrArr    []string       `json:"strArr" api:"attr" array:"true"`
-	StrPtrArr *[]string      `json:"strPtrArr" api:"attr" array:"true"`
-	Obj       testObjType    `json:"obj" api:"attr"`
-	ObjPtr    *testObjType   `json:"objPtr" api:"attr"`
-	ObjArr    []testObjType  `json:"objArr" api:"attr" array:"true"`
-	ObjArrPtr *[]testObjType `json:"objArrPtr" api:"attr" array:"true"`
+	Str           string         `json:"str" api:"attr"`
+	StrPtr        *string        `json:"strPtr" api:"attr"`
+	StrArr        []string       `json:"strArr" api:"attr"`
+	StrPtrArr     *[]string      `json:"strPtrArr" api:"attr"`
+	Obj           testObjType    `json:"obj" api:"attr"`
+	ObjPtr        *testObjType   `json:"objPtr" api:"attr"`
+	ObjArr        []testObjType  `json:"objArr" api:"attr"`
+	ObjArrPtr     *[]testObjType `json:"objArrPtr" api:"attr"`
+	Float32Matrix [][]float32    `json:"float32Matrix" api:"attr" array:"false"`
 }

--- a/range_test.go
+++ b/range_test.go
@@ -264,10 +264,11 @@ func TestSortResources(t *testing.T) {
 	typ := &Type{Name: "type"}
 
 	for i, t := range attrs {
-		ti, null := GetAttrType(fmt.Sprintf("%T", t.vals[0]))
+		ti, arr, null := GetAttrType(fmt.Sprintf("%T", t.vals[0]))
 		_ = typ.AddAttr(Attr{
 			Name:     "attr" + strconv.Itoa(i),
 			Type:     ti,
+			Array:    arr,
 			Nullable: null,
 		})
 	}

--- a/resource.go
+++ b/resource.go
@@ -34,6 +34,24 @@ func MarshalResource(r Resource, prepath string, fields []string, relData map[st
 	for _, attr := range r.Attrs() {
 		for _, field := range fields {
 			if field == attr.Name {
+				// AttrTypeUint8(Array=true) is handled like any other array.
+				// todo: check if there's a better way to do this
+				if attr.Type == AttrTypeUint8 && attr.Array {
+					v := r.Get(attr.Name)
+					var d *[]uint8
+					if attr.Nullable {
+						d = v.(*[]uint8)
+					} else {
+						a := v.([]uint8)
+						d = &a
+					}
+					attrs[attr.Name] = uint8Array{
+						Data:     d,
+						Nullable: attr.Nullable,
+					}
+					break
+				}
+
 				attrs[attr.Name] = r.Get(attr.Name)
 				break
 			}

--- a/resource.go
+++ b/resource.go
@@ -38,21 +38,26 @@ func MarshalResource(r Resource, prepath string, fields []string, relData map[st
 				// todo: check if there's a better way to do this
 				if attr.Type == AttrTypeUint8 && attr.Array {
 					v := r.Get(attr.Name)
+
 					var d *[]uint8
+
 					if attr.Nullable {
 						d = v.(*[]uint8)
 					} else {
 						a := v.([]uint8)
 						d = &a
 					}
+
 					attrs[attr.Name] = uint8Array{
 						Data:     d,
 						Nullable: attr.Nullable,
 					}
+
 					break
 				}
 
 				attrs[attr.Name] = r.Get(attr.Name)
+
 				break
 			}
 		}

--- a/resource_test.go
+++ b/resource_test.go
@@ -15,7 +15,8 @@ func TestUnmarshalPartialResource(t *testing.T) {
 	typ.NewFunc = func() Resource {
 		return Wrap(&mocktype{})
 	}
-	schema := &Schema{Types: []Type{typ}}
+	typ4, _ := BuildType(mockType4{})
+	schema := &Schema{Types: []Type{typ, typ4}}
 
 	// Tests
 	t.Run("partial resource", func(t *testing.T) {
@@ -56,6 +57,30 @@ func TestUnmarshalPartialResource(t *testing.T) {
 		assert.Equal("mocktype", res.GetType().Name)
 		assert.Len(res.Attrs(), 1)
 		assert.Len(res.Rels(), 2)
+	})
+
+	t.Run("partial resource arrays", func(t *testing.T) {
+		assert := assert.New(t)
+
+		payload := `{
+			"id": "id1",
+			"type": "mocktype4",
+			"attributes": {
+				"int8arr": [-32,-16, 0, 16, 32, 64, 127],
+				"intarr": []
+			}
+		}`
+
+		res, err := UnmarshalPartialResource([]byte(payload), schema)
+		assert.NoError(err)
+
+		assert.Equal("id1", res.GetID())
+		assert.Equal("mocktype4", res.GetType().Name)
+		assert.Len(res.Attrs(), 2)
+		assert.Len(res.Rels(), 0)
+
+		assert.Equal([]int{}, res.Get("intarr"))
+		assert.Equal([]int8{-32, -16, 0, 16, 32, 64, 127}, res.Get("int8arr"))
 	})
 
 	t.Run("partial resource (invalid attribute)", func(t *testing.T) {

--- a/resource_test.go
+++ b/resource_test.go
@@ -26,7 +26,8 @@ func TestUnmarshalPartialResource(t *testing.T) {
 			"id": "abc123",
 			"type": "mocktype",
 			"attributes": {
-				"str": "abc"
+				"str": "abc",
+				"float64": 123.456789
 			},
 			"relationships": {
 				"to-1": {
@@ -55,8 +56,11 @@ func TestUnmarshalPartialResource(t *testing.T) {
 
 		assert.Equal("abc123", res.GetID())
 		assert.Equal("mocktype", res.GetType().Name)
-		assert.Len(res.Attrs(), 1)
+		assert.Len(res.Attrs(), 2)
 		assert.Len(res.Rels(), 2)
+
+		assert.Equal("abc", res.Get("str"))
+		assert.Equal(123.456789, res.Get("float64"))
 	})
 
 	t.Run("partial resource arrays", func(t *testing.T) {

--- a/soft_resource.go
+++ b/soft_resource.go
@@ -2,6 +2,8 @@ package jsonapi
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 	"time"
 )
 
@@ -151,11 +153,24 @@ func (sr *SoftResource) Set(key string, v interface{}) {
 	}
 
 	if attr, ok := sr.Type.Attrs[key]; ok {
-		typ, _, nullable := GetAttrType(fmt.Sprintf("%T", v))
-		if attr.Type == typ && attr.Nullable == nullable {
-			sr.data[key] = v
-		} else if v == nil && attr.Nullable {
+		// Make sure the zero-value of arrays is not being overwritten by (typed) nil-values.
+		ref := reflect.ValueOf(v)
+		nilVal := v == nil || ((ref.Kind() == reflect.Ptr || ref.Kind() == reflect.Slice) && ref.IsNil())
+		if nilVal && (attr.Nullable || attr.Array) {
 			sr.data[key] = GetZeroValue(attr.Type, attr.Array, attr.Nullable)
+			return
+		}
+
+		// byte is an alias for uint8, so %T will return uint8.
+		t := fmt.Sprintf("%T", v)
+		if attr.Type == AttrTypeBytes && strings.HasSuffix(t, "uint8") {
+			t = strings.Replace(t, "uint8", "byte", 1)
+		}
+
+		typ, arr, null := GetAttrType(t)
+		if (attr.Type == typ && attr.Array == arr && attr.Nullable == null) ||
+			(attr.Type == AttrTypeBytes && arr && attr.Nullable == null) {
+			sr.data[key] = v
 		}
 	} else if rel, ok := sr.Type.Rels[key]; ok {
 		if _, ok := v.(string); ok && rel.ToOne {
@@ -222,7 +237,11 @@ func (sr *SoftResource) check() {
 	for i := range sr.Type.Attrs {
 		n := sr.Type.Attrs[i].Name
 		if _, ok := sr.data[n]; !ok {
-			sr.data[n] = GetZeroValue(sr.Type.Attrs[i].Type, sr.Type.Attrs[i].Array, sr.Type.Attrs[i].Nullable)
+			if sr.Type.Attrs[i].Type == AttrTypeBytes {
+				sr.data[n] = GetZeroValue(sr.Type.Attrs[i].Type, true, sr.Type.Attrs[i].Nullable)
+			} else {
+				sr.data[n] = GetZeroValue(sr.Type.Attrs[i].Type, sr.Type.Attrs[i].Array, sr.Type.Attrs[i].Nullable)
+			}
 		}
 	}
 
@@ -261,74 +280,177 @@ func copyData(d map[string]interface{}) map[string]interface{} {
 
 	for k, v := range d {
 		switch v2 := v.(type) {
-		case string:
-			d2[k] = v2
-		case int:
-			d2[k] = v2
-		case int8:
-			d2[k] = v2
-		case int16:
-			d2[k] = v2
-		case int32:
-			d2[k] = v2
-		case int64:
-			d2[k] = v2
-		case uint:
-			d2[k] = v2
-		case uint8:
-			d2[k] = v2
-		case uint16:
-			d2[k] = v2
-		case uint32:
-			d2[k] = v2
-		case uint64:
-			d2[k] = v2
-		case bool:
-			d2[k] = v2
-		case time.Time:
-			d2[k] = v2
-		case []uint8:
-			nv := make([]byte, len(v2))
-			_ = copy(nv, v2)
-			d2[k] = v2
+		// String array
 		case []string:
 			nv := make([]string, len(v2))
 			_ = copy(nv, v2)
 			d2[k] = v2
-		case *string:
+		case *[]string:
+			if v2 == nil {
+				d2[k] = (*[]string)(nil)
+			} else {
+				nv := make([]string, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Int array
+		case []int:
+			nv := make([]int, len(v2))
+			_ = copy(nv, v2)
 			d2[k] = v2
-		case *int:
+		case *[]int:
+			if v2 == nil {
+				d2[k] = (*[]int)(nil)
+			} else {
+				nv := make([]int, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Int8 array
+		case []int8:
+			nv := make([]int8, len(v2))
+			_ = copy(nv, v2)
 			d2[k] = v2
-		case *int8:
+		case *[]int8:
+			if v2 == nil {
+				d2[k] = (*[]int8)(nil)
+			} else {
+				nv := make([]int8, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Int16 array
+		case []int16:
+			nv := make([]int16, len(v2))
+			_ = copy(nv, v2)
 			d2[k] = v2
-		case *int16:
+		case *[]int16:
+			if v2 == nil {
+				d2[k] = (*[]int16)(nil)
+			} else {
+				nv := make([]int16, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Int32 array
+		case []int32:
+			nv := make([]int32, len(v2))
+			_ = copy(nv, v2)
 			d2[k] = v2
-		case *int32:
+		case *[]int32:
+			if v2 == nil {
+				d2[k] = (*[]int32)(nil)
+			} else {
+				nv := make([]int32, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Int64 array
+		case []int64:
+			nv := make([]int64, len(v2))
+			_ = copy(nv, v2)
 			d2[k] = v2
-		case *int64:
+		case *[]int64:
+			if v2 == nil {
+				d2[k] = (*[]int64)(nil)
+			} else {
+				nv := make([]int64, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Uint array
+		case []uint:
+			nv := make([]uint, len(v2))
+			_ = copy(nv, v2)
 			d2[k] = v2
-		case *uint:
-			d2[k] = v2
-		case *uint8:
-			d2[k] = v2
-		case *uint16:
-			d2[k] = v2
-		case *uint32:
-			d2[k] = v2
-		case *uint64:
-			d2[k] = v2
-		case *bool:
-			d2[k] = v2
-		case *time.Time:
+		case *[]uint:
+			if v2 == nil {
+				d2[k] = (*[]uint)(nil)
+			} else {
+				nv := make([]uint, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Uint8 array
+		case []uint8:
+			nv := make([]uint8, len(v2))
+			_ = copy(nv, v2)
 			d2[k] = v2
 		case *[]uint8:
 			if v2 == nil {
 				d2[k] = (*[]uint8)(nil)
 			} else {
-				nv := make([]byte, len(*v2))
+				nv := make([]uint8, len(*v2))
 				_ = copy(nv, *v2)
 				d2[k] = v2
 			}
+		// Uint16 array
+		case []uint16:
+			nv := make([]uint16, len(v2))
+			_ = copy(nv, v2)
+			d2[k] = v2
+		case *[]uint16:
+			if v2 == nil {
+				d2[k] = (*[]uint16)(nil)
+			} else {
+				nv := make([]uint16, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Uint32 array
+		case []uint32:
+			nv := make([]uint32, len(v2))
+			_ = copy(nv, v2)
+			d2[k] = v2
+		case *[]uint32:
+			if v2 == nil {
+				d2[k] = (*[]uint32)(nil)
+			} else {
+				nv := make([]uint32, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Uint64 array
+		case []uint64:
+			nv := make([]uint64, len(v2))
+			_ = copy(nv, v2)
+			d2[k] = v2
+		case *[]uint64:
+			if v2 == nil {
+				d2[k] = (*[]uint64)(nil)
+			} else {
+				nv := make([]uint64, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Bool array
+		case []bool:
+			nv := make([]bool, len(v2))
+			_ = copy(nv, v2)
+			d2[k] = v2
+		case *[]bool:
+			if v2 == nil {
+				d2[k] = (*[]bool)(nil)
+			} else {
+				nv := make([]bool, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		// Time array
+		case []time.Time:
+			nv := make([]time.Time, len(v2))
+			_ = copy(nv, v2)
+			d2[k] = v2
+		case *[]time.Time:
+			if v2 == nil {
+				d2[k] = (*[]time.Time)(nil)
+			} else {
+				nv := make([]time.Time, len(*v2))
+				_ = copy(nv, *v2)
+				d2[k] = v2
+			}
+		default:
+			d2[k] = v2
 		}
 	}
 

--- a/soft_resource.go
+++ b/soft_resource.go
@@ -2,7 +2,6 @@ package jsonapi
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"time"
 )
@@ -153,12 +152,7 @@ func (sr *SoftResource) Set(key string, v interface{}) {
 	}
 
 	if attr, ok := sr.Type.Attrs[key]; ok {
-		// Make sure the zero-value of arrays is not being overwritten by (typed) nil-values.
-		ref := reflect.ValueOf(v)
-		ptrOrSlice := ref.Kind() == reflect.Ptr || ref.Kind() == reflect.Slice
-		nilVal := v == nil || (ptrOrSlice && ref.IsNil())
-
-		if nilVal && (attr.Nullable || attr.Array) {
+		if isNil(v) {
 			if attr.Unmarshaler != nil {
 				sr.data[key] = attr.Unmarshaler.GetZeroValue(attr.Array, attr.Nullable)
 			} else {

--- a/soft_resource.go
+++ b/soft_resource.go
@@ -151,11 +151,11 @@ func (sr *SoftResource) Set(key string, v interface{}) {
 	}
 
 	if attr, ok := sr.Type.Attrs[key]; ok {
-		typ, nullable := GetAttrType(fmt.Sprintf("%T", v))
+		typ, _, nullable := GetAttrType(fmt.Sprintf("%T", v))
 		if attr.Type == typ && attr.Nullable == nullable {
 			sr.data[key] = v
 		} else if v == nil && attr.Nullable {
-			sr.data[key] = GetZeroValue(attr.Type, attr.Nullable)
+			sr.data[key] = GetZeroValue(attr.Type, attr.Array, attr.Nullable)
 		}
 	} else if rel, ok := sr.Type.Rels[key]; ok {
 		if _, ok := v.(string); ok && rel.ToOne {
@@ -222,7 +222,7 @@ func (sr *SoftResource) check() {
 	for i := range sr.Type.Attrs {
 		n := sr.Type.Attrs[i].Name
 		if _, ok := sr.data[n]; !ok {
-			sr.data[n] = GetZeroValue(sr.Type.Attrs[i].Type, sr.Type.Attrs[i].Nullable)
+			sr.data[n] = GetZeroValue(sr.Type.Attrs[i].Type, sr.Type.Attrs[i].Array, sr.Type.Attrs[i].Nullable)
 		}
 	}
 

--- a/soft_resource.go
+++ b/soft_resource.go
@@ -155,7 +155,9 @@ func (sr *SoftResource) Set(key string, v interface{}) {
 	if attr, ok := sr.Type.Attrs[key]; ok {
 		// Make sure the zero-value of arrays is not being overwritten by (typed) nil-values.
 		ref := reflect.ValueOf(v)
-		nilVal := v == nil || ((ref.Kind() == reflect.Ptr || ref.Kind() == reflect.Slice) && ref.IsNil())
+		ptrOrSlice := ref.Kind() == reflect.Ptr || ref.Kind() == reflect.Slice
+		nilVal := v == nil || (ptrOrSlice && ref.IsNil())
+
 		if nilVal && (attr.Nullable || attr.Array) {
 			sr.data[key] = GetZeroValue(attr.Type, attr.Array, attr.Nullable)
 			return
@@ -235,12 +237,13 @@ func (sr *SoftResource) check() {
 	}
 
 	for i := range sr.Type.Attrs {
-		n := sr.Type.Attrs[i].Name
-		if _, ok := sr.data[n]; !ok {
-			if sr.Type.Attrs[i].Type == AttrTypeBytes {
-				sr.data[n] = GetZeroValue(sr.Type.Attrs[i].Type, true, sr.Type.Attrs[i].Nullable)
+		attr := sr.Type.Attrs[i]
+
+		if _, ok := sr.data[attr.Name]; !ok {
+			if attr.Type == AttrTypeBytes {
+				sr.data[attr.Name] = GetZeroValue(attr.Type, true, attr.Nullable)
 			} else {
-				sr.data[n] = GetZeroValue(sr.Type.Attrs[i].Type, sr.Type.Attrs[i].Array, sr.Type.Attrs[i].Nullable)
+				sr.data[attr.Name] = GetZeroValue(attr.Type, attr.Array, attr.Nullable)
 			}
 		}
 	}

--- a/soft_resource_test.go
+++ b/soft_resource_test.go
@@ -164,6 +164,13 @@ func TestSoftResource(t *testing.T) {
 	assert.Equal(t, []string{"id1", "id2"}, sr.Get("rel2").([]string))
 
 	// test setting nil values
+	sr.Set("attr1", "test")
+	sr.Set("attr1", nil)
+	assert.Equal(t, "", sr.Get("attr1"))
+	sr.Set("attr1", "test")
+	sr.Set("attr1", (*map[int]string)(nil))
+	assert.Equal(t, "", sr.Get("attr1"))
+
 	sr.Set("attr3", []string{"foo", "bar"})
 	sr.Set("attr3", nil)
 	assert.Equal(t, []string{}, sr.Get("attr3"))

--- a/soft_resource_test.go
+++ b/soft_resource_test.go
@@ -236,25 +236,17 @@ func TestSoftResourceCopy(t *testing.T) {
 	}
 
 	for t, v := range attrs {
-		typ, null := GetAttrType(t)
+		typ, arr, null := GetAttrType(t)
 
 		sr.AddAttr(Attr{
 			Name:     t,
 			Type:     typ,
+			Array:    arr,
 			Nullable: null,
 		})
 
 		sr.Set(t, v)
 	}
-
-	// Special cases
-	sr.AddAttr(Attr{
-		Name:     "nil-*[]byte",
-		Type:     AttrTypeBytes,
-		Nullable: true,
-	})
-
-	sr.Set("nil-*[]byte", (*[]byte)(nil))
 
 	// Relationships
 	sr.AddRel(Rel{

--- a/soft_resource_test.go
+++ b/soft_resource_test.go
@@ -57,6 +57,27 @@ func TestSoftResource(t *testing.T) {
 			Type:     AttrTypeString,
 			Nullable: true,
 		},
+		"attr3": {
+			Name:     "attr3",
+			Type:     AttrTypeString,
+			Array:    true,
+			Nullable: false,
+		},
+		"attr4": {
+			Name:     "attr4",
+			Type:     AttrTypeString,
+			Array:    true,
+			Nullable: true,
+		},
+		"attr5": {
+			Name: "attr5",
+			Type: AttrTypeBytes,
+		},
+		"attr6": {
+			Name:     "attr6",
+			Type:     AttrTypeBytes,
+			Nullable: true,
+		},
 	}
 	for _, attr := range attrs {
 		sr.AddAttr(attr)
@@ -96,6 +117,10 @@ func TestSoftResource(t *testing.T) {
 	sr.RemoveField("attr1")
 	assert.Equal(t, Attr{}, sr.Attr("attr1"))
 	sr.RemoveField("attr2")
+	sr.RemoveField("attr3")
+	sr.RemoveField("attr4")
+	sr.RemoveField("attr5")
+	sr.RemoveField("attr6")
 	assert.Equal(t, map[string]Attr{}, sr.Attrs())
 
 	sr.RemoveField("rel1")
@@ -120,14 +145,43 @@ func TestSoftResource(t *testing.T) {
 
 	// Set and get some fields
 	assert.Equal(t, "", sr.Get("attr1"))
+	assert.Equal(t, (*string)(nil), sr.Get("attr2"))
+	assert.Equal(t, []string{}, sr.Get("attr3"))
+	assert.Equal(t, (*[]string)(nil), sr.Get("attr4"))
+	assert.Equal(t, []byte{}, sr.Get("attr5"))
+	assert.Equal(t, (*[]byte)(nil), sr.Get("attr6"))
 	assert.Equal(t, "", sr.Get("rel1").(string))
 	assert.Equal(t, []string{}, sr.Get("rel2").([]string))
 	sr.Set("attr1", "value")
+	sr.Set("attr3", []string{"foo", "bar"})
+	sr.Set("attr4", &[]string{"foo", "bar"})
 	sr.Set("rel1", "id1")
 	sr.Set("rel2", []string{"id1", "id2"})
 	assert.Equal(t, "value", sr.Get("attr1"))
+	assert.Equal(t, []string{"foo", "bar"}, sr.Get("attr3"))
+	assert.Equal(t, &[]string{"foo", "bar"}, sr.Get("attr4"))
 	assert.Equal(t, "id1", sr.Get("rel1").(string))
 	assert.Equal(t, []string{"id1", "id2"}, sr.Get("rel2").([]string))
+
+	// test setting nil values
+	sr.Set("attr3", []string{"foo", "bar"})
+	sr.Set("attr3", nil)
+	assert.Equal(t, []string{}, sr.Get("attr3"))
+
+	sr.Set("attr3", []string{"foo", "bar"})
+	sr.Set("attr3", ([]string)(nil))
+	assert.Equal(t, []string{}, sr.Get("attr3"))
+
+	sr.Set("attr4", &[]string{"foo", "bar"})
+	sr.Set("attr4", nil)
+	assert.Equal(t, (*[]string)(nil), sr.Get("attr4"))
+
+	sr.Set("attr4", &[]string{"foo", "bar"})
+	sr.Set("attr4", (*[]string)(nil))
+	assert.Equal(t, (*[]string)(nil), sr.Get("attr4"))
+
+	sr.Set("attr3", "some invalid value")
+	assert.Equal(t, []string{}, sr.Get("attr3"))
 
 	// Set a nullable attribute to nil
 	_ = sr.Type.AddAttr(Attr{
@@ -205,34 +259,70 @@ func TestSoftResourceCopy(t *testing.T) {
 
 	// Attributes
 	attrs := map[string]interface{}{
-		"string":     "abc",
-		"int":        42,
-		"int8":       8,
-		"int16":      16,
-		"int32":      32,
-		"int64":      64,
-		"uint":       42,
-		"uint8":      8,
-		"uint16":     16,
-		"uint32":     32,
-		"uint64":     64,
-		"bool":       true,
-		"time.Time":  now,
-		"[]uint8":    []byte{'a', 'b', 'c'},
-		"*string":    ptr("abc"),
-		"*int":       ptr(42),
-		"*int8":      ptr(8),
-		"*int16":     ptr(16),
-		"*int32":     ptr(32),
-		"*int64":     ptr(64),
-		"*uint":      ptr(42),
-		"*uint8":     ptr(8),
-		"*uint16":    ptr(16),
-		"*uint32":    ptr(32),
-		"*uint64":    ptr(64),
-		"*bool":      ptr(true),
-		"*time.Time": ptr(now),
-		"*[]uint8":   ptr([]byte{'a', 'b', 'c'}),
+		"string":    "abc",
+		"*string":   ptr("abc"),
+		"[]string":  []string{"abc"},
+		"*[]string": &[]string{"abc"},
+
+		"int":    42,
+		"*int":   ptr(42),
+		"[]int":  []int{42},
+		"*[]int": &[]int{42},
+
+		"int8":    8,
+		"*int8":   ptr(8),
+		"[]int8":  []int8{8},
+		"*[]int8": &[]int8{8},
+
+		"int16":    16,
+		"*int16":   ptr(16),
+		"[]int16":  []int16{16},
+		"*[]int16": &[]int16{16},
+
+		"int32":    32,
+		"*int32":   ptr(32),
+		"[]int32":  []int32{32},
+		"*[]int32": &[]int32{32},
+
+		"int64":    64,
+		"*int64":   ptr(64),
+		"[]int64":  []int64{64},
+		"*[]int64": &[]int64{64},
+
+		"uint":    42,
+		"*uint":   ptr(42),
+		"[]uint":  []uint{42},
+		"*[]uint": &[]uint{42},
+
+		"uint8":    8,
+		"*uint8":   ptr(8),
+		"[]uint8":  []byte{'a', 'b', 'c'},
+		"*[]uint8": &[]byte{'a', 'b', 'c'},
+
+		"uint16":    16,
+		"*uint16":   ptr(16),
+		"[]uint16":  []uint16{16},
+		"*[]uint16": &[]uint16{16},
+
+		"uint32":    32,
+		"*uint32":   ptr(32),
+		"[]uint32":  []uint32{32},
+		"*[]uint32": &[]uint32{32},
+
+		"uint64":    64,
+		"*uint64":   ptr(64),
+		"[]uint64":  []uint64{64},
+		"*[]uint64": &[]uint64{64},
+
+		"bool":    true,
+		"*bool":   ptr(true),
+		"[]bool":  []bool{true},
+		"*[]bool": &[]bool{true},
+
+		"time.Time":    now,
+		"*time.Time":   ptr(now),
+		"[]time.Time":  []time.Time{now},
+		"*[]time.Time": &[]time.Time{now},
 	}
 
 	for t, v := range attrs {
@@ -246,6 +336,67 @@ func TestSoftResourceCopy(t *testing.T) {
 		})
 
 		sr.Set(t, v)
+	}
+
+	// Special cases
+	specialAttrs := map[string]struct {
+		attr Attr
+		val  interface{}
+	}{
+		"nil-*[]string": {
+			attr: Attr{Type: AttrTypeString, Array: true, Nullable: true},
+			val:  nil,
+		},
+		"typed-nil-*[]int": {
+			attr: Attr{Type: AttrTypeInt, Array: true, Nullable: true},
+			val:  (*[]int)(nil),
+		},
+		"nil-*[]int8": {
+			attr: Attr{Type: AttrTypeInt8, Array: true, Nullable: true},
+			val:  nil,
+		},
+		"typed-nil-*[]int16": {
+			attr: Attr{Type: AttrTypeInt16, Array: true, Nullable: true},
+			val:  (*[]int16)(nil),
+		},
+		"nil-*[]int32": {
+			attr: Attr{Type: AttrTypeInt32, Array: true, Nullable: true},
+			val:  nil},
+		"typed-nil-*[]int64": {
+			attr: Attr{Type: AttrTypeInt64, Array: true, Nullable: true},
+			val:  (*[]int64)(nil)},
+
+		"typed-nil-*[]uint": {
+			attr: Attr{Type: AttrTypeUint, Array: true, Nullable: true},
+			val:  (*[]uint)(nil)},
+		"nil-*[]uint8": {
+			attr: Attr{Type: AttrTypeUint8, Array: true, Nullable: true},
+			val:  nil},
+		"typed-nil-*[]uint16": {
+			attr: Attr{Type: AttrTypeUint16, Array: true, Nullable: true},
+			val:  (*[]uint16)(nil)},
+		"nil-*[]uint32": {
+			attr: Attr{Type: AttrTypeUint32, Array: true, Nullable: true},
+			val:  nil},
+		"typed-nil-*[]uint64": {
+			attr: Attr{Type: AttrTypeUint64, Array: true, Nullable: true},
+			val:  (*[]uint64)(nil)},
+
+		"nil-*[]byte": {
+			attr: Attr{Type: AttrTypeBytes, Nullable: true},
+			val:  nil},
+		"typed-nil-*[]bool": {
+			attr: Attr{Type: AttrTypeBool, Array: true, Nullable: true},
+			val:  (*[]bool)(nil)},
+		"nil-*[]time.Time": {
+			attr: Attr{Type: AttrTypeTime, Array: true, Nullable: true},
+			val:  nil},
+	}
+
+	for name, data := range specialAttrs {
+		data.attr.Name = name
+		sr.AddAttr(data.attr)
+		sr.Set(name, data.val)
 	}
 
 	// Relationships
@@ -289,10 +440,12 @@ func TestSoftResourceMeta(t *testing.T) {
 }
 
 func TestSoftResourceGetSetID(t *testing.T) {
-	assert := assert.New(t)
-
 	sr := &SoftResource{}
 	sr.Set("id", "abc123")
+	assert.Equal(t, "abc123", sr.GetID())
+	assert.Equal(t, "abc123", sr.Get("id"))
 
-	assert.Equal("abc123", sr.Get("id"))
+	sr.SetID("def456")
+	assert.Equal(t, "def456", sr.GetID())
+	assert.Equal(t, "def456", sr.Get("id"))
 }

--- a/testdata/goldenfiles/marshaling/collection.json
+++ b/testdata/goldenfiles/marshaling/collection.json
@@ -143,12 +143,32 @@
 				}
 			},
 			"type": "mocktype"
+		},
+		{
+			"attributes": {
+				"obj": {
+					"prop1": "abc",
+					"prop2": "def",
+					"prop3": "ghi"
+				},
+				"objPtr": {
+					"prop1": "jkl",
+					"prop2": "mno",
+					"prop3": "pqr"
+				},
+				"objArr": []
+			},
+			"id": "test-123",
+			"links": {
+				"self": "https://example.org/mocktype6/test-123"
+			},
+			"type": "mocktype6"
 		}
 	],
 	"jsonapi": {
 		"version": "1.0"
 	},
 	"links": {
-		"self": "https://example.org/fake/path?fields%5Bmocktype%5D=bool%2Cint%2Cstr%2Ctime%2Cto-1%2Cto-x-from-1%2Cuint64\u0026fields%5Bmocktypes1%5D=str"
+		"self": "https://example.org/fake/path?fields%5Bmocktype%5D=bool%2Cint%2Cstr%2Ctime%2Cto-1%2Cto-x-from-1%2Cuint64\u0026fields%5Bmocktype6%5D=obj%2CobjArr%2CobjPtr\u0026fields%5Bmocktypes1%5D=str"
 	}
 }

--- a/testdata/goldenfiles/marshaling/collection.json
+++ b/testdata/goldenfiles/marshaling/collection.json
@@ -156,7 +156,11 @@
 					"prop2": "mno",
 					"prop3": "pqr"
 				},
-				"objArr": []
+				"objArr": [],
+				"float32Matrix": [
+					[1.0, 0.5, 0.25, 0.175],
+					[0.175, 0.25, 0.5, 1.0]
+				]
 			},
 			"id": "test-123",
 			"links": {
@@ -169,6 +173,6 @@
 		"version": "1.0"
 	},
 	"links": {
-		"self": "https://example.org/fake/path?fields%5Bmocktype%5D=bool%2Cint%2Cstr%2Ctime%2Cto-1%2Cto-x-from-1%2Cuint64\u0026fields%5Bmocktype6%5D=obj%2CobjArr%2CobjPtr\u0026fields%5Bmocktypes1%5D=str"
+		"self": "https://example.org/fake/path?fields%5Bmocktype%5D=bool%2Cint%2Cstr%2Ctime%2Cto-1%2Cto-x-from-1%2Cuint64\u0026fields%5Bmocktype6%5D=float32Matrix%2Cobj%2CobjArr%2CobjPtr\u0026fields%5Bmocktypes1%5D=str"
 	}
 }

--- a/testdata/goldenfiles/marshaling/collection.json
+++ b/testdata/goldenfiles/marshaling/collection.json
@@ -40,6 +40,16 @@
 		},
 		{
 			"attributes": {
+				"str": "str with \u003chtml\u003e chars"
+			},
+			"id": "id1",
+			"links": {
+				"self": "https://example.org/mocktypes1/id1"
+			},
+			"type": "mocktypes1"
+		},
+		{
+			"attributes": {
 				"bool": false,
 				"int": -42,
 				"str": "漢語",
@@ -139,6 +149,6 @@
 		"version": "1.0"
 	},
 	"links": {
-		"self": "https://example.org/fake/path?fields%5Bmocktype%5D=bool%2Cint%2Cstr%2Ctime%2Cto-1%2Cto-x-from-1%2Cuint64"
+		"self": "https://example.org/fake/path?fields%5Bmocktype%5D=bool%2Cint%2Cstr%2Ctime%2Cto-1%2Cto-x-from-1%2Cuint64\u0026fields%5Bmocktypes1%5D=str"
 	}
 }

--- a/testdata/goldenfiles/marshaling/resource.json
+++ b/testdata/goldenfiles/marshaling/resource.json
@@ -5,6 +5,8 @@
 			"bytes": "AQID",
 			"int": 10,
 			"str": "str",
+			"float32": 3.4028235e+38,
+			"float64": 1.7976931348623157e+308,
 			"time": "2013-06-24T22:03:34.8276Z",
 			"uint64": 1064
 		},
@@ -42,6 +44,6 @@
 		"version": "1.0"
 	},
 	"links": {
-		"self": "/fake/path?fields%5Bmocktype%5D=bool%2Cbytes%2Cint%2Cstr%2Ctime%2Cto-1%2Cto-x-from-1%2Cuint64"
+		"self": "/fake/path?fields%5Bmocktype%5D=bool%2Cbytes%2Cfloat32%2Cfloat64%2Cint%2Cstr%2Ctime%2Cto-1%2Cto-x-from-1%2Cuint64"
 	}
 }

--- a/testdata/goldenfiles/marshaling/resource_array_attributes.json
+++ b/testdata/goldenfiles/marshaling/resource_array_attributes.json
@@ -1,0 +1,44 @@
+{
+	"data": {
+		"attributes": {
+			"strarr": [
+				"foo",
+				"bar",
+				"baz"
+			],
+			"int8arr": [
+				-100,
+				-50,
+				0,
+				50,
+				100
+			],
+			"int32arr": [
+				-10000000,
+				123456,
+				-45,
+				333333333
+			],
+			"uint8arr": "aGVsbG8gd29ybGQ=",
+			"boolarr": [
+				true,
+				false,
+				true,
+				true
+			],
+			"int16arr": []
+		},
+		"id": "id1",
+		"links": {
+			"self": "/mocktype4/id1"
+		},
+
+		"type": "mocktype4"
+	},
+	"jsonapi": {
+		"version": "1.0"
+	},
+	"links": {
+		"self": "/fake/path?fields%5Bmocktype4%5D=boolarr%2Cint16arr%2Cint32arr%2Cint8arr%2Cstrarr%2Cuint8arr"
+	}
+}

--- a/testdata/goldenfiles/marshaling/resource_array_attributes.json
+++ b/testdata/goldenfiles/marshaling/resource_array_attributes.json
@@ -26,7 +26,13 @@
 				true,
 				true
 			],
-			"int16arr": []
+			"int16arr": [],
+			"float32arr": [
+				3.4028235e+38
+			],
+			"float64arr": [
+				1.7976931348623157e+308
+			]
 		},
 		"id": "id1",
 		"links": {
@@ -39,6 +45,6 @@
 		"version": "1.0"
 	},
 	"links": {
-		"self": "/fake/path?fields%5Bmocktype4%5D=boolarr%2Cint16arr%2Cint32arr%2Cint8arr%2Cstrarr%2Cuint8arr"
+		"self": "/fake/path?fields%5Bmocktype4%5D=boolarr%2Cfloat32arr%2Cfloat64arr%2Cint16arr%2Cint32arr%2Cint8arr%2Cstrarr%2Cuint8arr"
 	}
 }

--- a/testdata/goldenfiles/marshaling/resource_bytes.json
+++ b/testdata/goldenfiles/marshaling/resource_bytes.json
@@ -1,0 +1,26 @@
+{
+	"data": {
+		"attributes": {
+			"uint8arr": [1, 2, 4, 8, 16, 32],
+			"uint8arrptr": [1, 2, 4, 8, 16, 32],
+			"uint8arrempty": [],
+			"uint8arrptrnull": null,
+			"bytes": "AQIECBAg",
+			"bytesptr": "AQIECBAg",
+			"nullbytes": "",
+			"nullbytesptr": null
+		},
+		"id": "id1",
+		"links": {
+			"self": "/bytestest/id1"
+		},
+
+		"type": "bytestest"
+	},
+	"jsonapi": {
+		"version": "1.0"
+	},
+	"links": {
+		"self": "/fake/path?fields%5Bbytestest%5D=bytes%2Cbytesptr%2Cnullbytes%2Cnullbytesptr%2Cuint8arr%2Cuint8arrempty%2Cuint8arrptr%2Cuint8arrptrnull"
+	}
+}

--- a/testdata/goldenfiles/marshaling/resource_nullable_array_attributes.json
+++ b/testdata/goldenfiles/marshaling/resource_nullable_array_attributes.json
@@ -21,7 +21,9 @@
 				true,
 				true
 			],
-			"int16arrptr": null
+			"int16arrptr": null,
+			"float32arrptr": [3.4028235e+38],
+			"float64arrptr": null
 		},
 		"id": "id1",
 		"links": {
@@ -34,6 +36,6 @@
 		"version": "1.0"
 	},
 	"links": {
-		"self": "/fake/path?fields%5Bmocktype5%5D=boolarrptr%2Cint16arrptr%2Cint32arrptr%2Cint8arrptr%2Cstrarrptr%2Cuint8arrptr"
+		"self": "/fake/path?fields%5Bmocktype5%5D=boolarrptr%2Cfloat32arrptr%2Cfloat64arrptr%2Cint16arrptr%2Cint32arrptr%2Cint8arrptr%2Cstrarrptr%2Cuint8arrptr"
 	}
 }

--- a/testdata/goldenfiles/marshaling/resource_nullable_array_attributes.json
+++ b/testdata/goldenfiles/marshaling/resource_nullable_array_attributes.json
@@ -1,0 +1,39 @@
+{
+	"data": {
+		"attributes": {
+			"strarrptr": [
+				"foo",
+				"bar",
+				"baz"
+			],
+			"int8arrptr": [
+				-100,
+				-50,
+				0,
+				50,
+				100
+			],
+			"int32arrptr": null,
+			"uint8arrptr": null,
+			"boolarrptr": [
+				true,
+				false,
+				true,
+				true
+			],
+			"int16arrptr": null
+		},
+		"id": "id1",
+		"links": {
+			"self": "/mocktype5/id1"
+		},
+
+		"type": "mocktype5"
+	},
+	"jsonapi": {
+		"version": "1.0"
+	},
+	"links": {
+		"self": "/fake/path?fields%5Bmocktype5%5D=boolarrptr%2Cint16arrptr%2Cint32arrptr%2Cint8arrptr%2Cstrarrptr%2Cuint8arrptr"
+	}
+}

--- a/testdata/goldenfiles/marshaling/resource_object_property.json
+++ b/testdata/goldenfiles/marshaling/resource_object_property.json
@@ -18,7 +18,15 @@
 					"prop3": "f"
 				}
 			],
-			"objptr": null
+			"objptr": null,
+			"float32MatrixArr": [
+				[
+					[0.1, 0.2, 0.3, 0.4, 0.5]
+				],
+				[
+					[0.6, 0.7, 0.8, 0.9, 1.0]
+				]
+			]
 		},
 		"id": "id1",
 		"links": {
@@ -31,6 +39,6 @@
 		"version": "1.0"
 	},
 	"links": {
-		"self": "/fake/path?fields%5Bobjtest%5D=obj%2Cobjarr%2Cobjptr%2Cobjptrarr"
+		"self": "/fake/path?fields%5Bobjtest%5D=float32MatrixArr%2Cobj%2Cobjarr%2Cobjptr%2Cobjptrarr"
 	}
 }

--- a/testdata/goldenfiles/marshaling/resource_object_property.json
+++ b/testdata/goldenfiles/marshaling/resource_object_property.json
@@ -1,0 +1,36 @@
+{
+	"data": {
+		"attributes": {
+			"obj": {
+				"prop1": "foo",
+				"prop2": "bar",
+				"prop3": "baz"
+			},
+			"objarr": [
+				{
+					"prop1": "a",
+					"prop2": "b",
+					"prop3": "c"
+				},
+				{
+					"prop1": "d",
+					"prop2": "e",
+					"prop3": "f"
+				}
+			],
+			"objptr": null
+		},
+		"id": "id1",
+		"links": {
+			"self": "/objtest/id1"
+		},
+
+		"type": "objtest"
+	},
+	"jsonapi": {
+		"version": "1.0"
+	},
+	"links": {
+		"self": "/fake/path?fields%5Bobjtest%5D=obj%2Cobjarr%2Cobjptr%2Cobjptrarr"
+	}
+}

--- a/type.go
+++ b/type.go
@@ -732,7 +732,7 @@ func GetAttrTypeString(t int, array, nullable bool) string {
 	case AttrTypeTime:
 		str = "time.Time"
 	default:
-		str = ""
+		return ""
 	}
 
 	if array {

--- a/type.go
+++ b/type.go
@@ -19,13 +19,13 @@ import (
 // even if it potentially can break existing code.
 //
 // The names are as follow:
-//  - string
-//  - int, int8, int16, int32, int64
-//  - uint, uint8, uint16, uint32, uint64
-//  - float32, float64
-//  - bool
-//  - time (Go type is time.Time)
-//  - []byte
+//   - string
+//   - int, int8, int16, int32, int64
+//   - uint, uint8, uint16, uint32, uint64
+//   - float32, float64
+//   - bool
+//   - time (Go type is time.Time)
+//   - []byte
 //
 // An asterisk is present as a prefix if the type is nullable (like *string), brackets
 // if it is an array (e.g. []string). Nullable arrays combine asterisk and
@@ -68,6 +68,7 @@ func (u uint8Array) MarshalJSON() ([]byte, error) {
 	} else {
 		result = strings.Join(strings.Fields(fmt.Sprintf("%d", *u.Data)), ",")
 	}
+
 	return []byte(result), nil
 }
 
@@ -232,7 +233,11 @@ type Attr struct {
 // the attribute and returns it.
 func (a Attr) UnmarshalToType(data []byte) (interface{}, error) {
 	if data == nil || (!a.Nullable && string(data) == "null") {
-		return nil, NewErrInvalidFieldValueInBody(a.Name, string(data), GetAttrTypeString(a.Type, a.Array, a.Nullable))
+		return nil, NewErrInvalidFieldValueInBody(
+			a.Name,
+			string(data),
+			GetAttrTypeString(a.Type, a.Array, a.Nullable),
+		)
 	}
 
 	if a.Nullable && string(data) == "null" {
@@ -469,6 +474,7 @@ func (a Attr) UnmarshalToType(data []byte) (interface{}, error) {
 		if a.Array {
 			var fa []float32
 			err = json.Unmarshal(data, &fa)
+
 			if a.Nullable {
 				v = &fa
 			} else {
@@ -488,6 +494,7 @@ func (a Attr) UnmarshalToType(data []byte) (interface{}, error) {
 		if a.Array {
 			var fa []float64
 			err = json.Unmarshal(data, &fa)
+
 			if a.Nullable {
 				v = &fa
 			} else {
@@ -633,11 +640,12 @@ func GetAttrType(t string) (typ int, array bool, nullable bool) {
 	array = bi == 0 || bi == 1
 	nullable = strings.HasPrefix(t, "*")
 
-	if nullable && array {
+	switch {
+	case nullable && array:
 		t = t[3:]
-	} else if array {
+	case array:
 		t = t[2:]
-	} else if nullable {
+	case nullable:
 		t = t[1:]
 	}
 
@@ -739,71 +747,78 @@ func GetAttrTypeString(t int, array, nullable bool) string {
 func GetZeroValue(t int, array, nullable bool) interface{} {
 	switch t {
 	case AttrTypeString:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]string)(nil)
-		} else if array {
+		case array:
 			return []string{}
-		} else if nullable {
+		case nullable:
 			return (*string)(nil)
 		}
 
 		return ""
 	case AttrTypeInt:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]int)(nil)
-		} else if array {
+		case array:
 			return []int{}
-		} else if nullable {
+		case nullable:
 			return (*int)(nil)
 		}
 
 		return 0
 	case AttrTypeInt8:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]int8)(nil)
-		} else if array {
+		case array:
 			return []int8{}
-		} else if nullable {
+		case nullable:
 			return (*int8)(nil)
 		}
 
 		return int8(0)
 	case AttrTypeInt16:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]int16)(nil)
-		} else if array {
+		case array:
 			return []int16{}
-		} else if nullable {
+		case nullable:
 			return (*int16)(nil)
 		}
 
 		return int16(0)
 	case AttrTypeInt32:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]int32)(nil)
-		} else if array {
+		case array:
 			return []int32{}
-		} else if nullable {
+		case nullable:
 			return (*int32)(nil)
 		}
 
 		return int32(0)
 	case AttrTypeInt64:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]int64)(nil)
-		} else if array {
+		case array:
 			return []int64{}
-		} else if nullable {
+		case nullable:
 			return (*int64)(nil)
 		}
 
 		return int64(0)
 	case AttrTypeUint:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]uint)(nil)
-		} else if array {
+		case array:
 			return []uint{}
-		} else if nullable {
+		case nullable:
 			return (*uint)(nil)
 		}
 
@@ -813,81 +828,89 @@ func GetZeroValue(t int, array, nullable bool) interface{} {
 			array = true
 		}
 
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]uint8)(nil)
-		} else if array {
+		case array:
 			return []uint8{}
-		} else if nullable {
+		case nullable:
 			return (*uint8)(nil)
 		}
 
 		return uint8(0)
 	case AttrTypeUint16:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]uint16)(nil)
-		} else if array {
+		case array:
 			return []uint16{}
-		} else if nullable {
+		case nullable:
 			return (*uint16)(nil)
 		}
 
 		return uint16(0)
 	case AttrTypeUint32:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]uint32)(nil)
-		} else if array {
+		case array:
 			return []uint32{}
-		} else if nullable {
+		case nullable:
 			return (*uint32)(nil)
 		}
 
 		return uint32(0)
 	case AttrTypeUint64:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]uint64)(nil)
-		} else if array {
+		case array:
 			return []uint64{}
-		} else if nullable {
+		case nullable:
 			return (*uint64)(nil)
 		}
 
 		return uint64(0)
 	case AttrTypeFloat32:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]float32)(nil)
-		} else if array {
+		case array:
 			return []float32{}
-		} else if nullable {
+		case nullable:
 			return (*float32)(nil)
 		}
 
 		return float32(0)
 	case AttrTypeFloat64:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]float64)(nil)
-		} else if array {
+		case array:
 			return []float64{}
-		} else if nullable {
+		case nullable:
 			return (*float64)(nil)
 		}
 
 		return float64(0)
 	case AttrTypeBool:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]bool)(nil)
-		} else if array {
+		case array:
 			return []bool{}
-		} else if nullable {
+		case nullable:
 			return (*bool)(nil)
 		}
 
 		return false
 	case AttrTypeTime:
-		if array && nullable {
+		switch {
+		case nullable && array:
 			return (*[]time.Time)(nil)
-		} else if array {
+		case array:
 			return []time.Time{}
-		} else if nullable {
+		case nullable:
 			return (*time.Time)(nil)
 		}
 

--- a/type.go
+++ b/type.go
@@ -22,6 +22,7 @@ import (
 //  - string
 //  - int, int8, int16, int32, int64
 //  - uint, uint8, uint16, uint32, uint64
+//  - float32, float64
 //  - bool
 //  - time (Go type is time.Time)
 //  - []byte
@@ -45,6 +46,8 @@ const (
 	AttrTypeUint16
 	AttrTypeUint32
 	AttrTypeUint64
+	AttrTypeFloat32
+	AttrTypeFloat64
 	AttrTypeBool
 	AttrTypeTime
 	AttrTypeBytes
@@ -462,6 +465,44 @@ func (a Attr) UnmarshalToType(data []byte) (interface{}, error) {
 				v = v.(uint64)
 			}
 		}
+	case AttrTypeFloat32:
+		if a.Array {
+			var fa []float32
+			err = json.Unmarshal(data, &fa)
+			if a.Nullable {
+				v = &fa
+			} else {
+				v = fa
+			}
+		} else {
+			var f64 float64
+			f64, err = strconv.ParseFloat(string(data), 32)
+			if a.Nullable {
+				n := float32(f64)
+				v = &n
+			} else {
+				v = float32(f64)
+			}
+		}
+	case AttrTypeFloat64:
+		if a.Array {
+			var fa []float64
+			err = json.Unmarshal(data, &fa)
+			if a.Nullable {
+				v = &fa
+			} else {
+				v = fa
+			}
+		} else {
+			var f64 float64
+			f64, err = strconv.ParseFloat(string(data), 64)
+			if a.Nullable {
+				n := f64
+				v = &n
+			} else {
+				v = f64
+			}
+		}
 	case AttrTypeBool:
 		if a.Array {
 			var ba []bool
@@ -623,6 +664,10 @@ func GetAttrType(t string) (typ int, array bool, nullable bool) {
 		return AttrTypeUint32, array, nullable
 	case "uint64":
 		return AttrTypeUint64, array, nullable
+	case "float32":
+		return AttrTypeFloat32, array, nullable
+	case "float64":
+		return AttrTypeFloat64, array, nullable
 	case "bool":
 		return AttrTypeBool, array, nullable
 	case "time.Time":
@@ -663,6 +708,10 @@ func GetAttrTypeString(t int, array, nullable bool) string {
 		str = "uint32"
 	case AttrTypeUint64:
 		str = "uint64"
+	case AttrTypeFloat32:
+		str = "float32"
+	case AttrTypeFloat64:
+		str = "float64"
 	case AttrTypeBool:
 		str = "bool"
 	case AttrTypeTime:
@@ -803,6 +852,26 @@ func GetZeroValue(t int, array, nullable bool) interface{} {
 		}
 
 		return uint64(0)
+	case AttrTypeFloat32:
+		if array && nullable {
+			return (*[]float32)(nil)
+		} else if array {
+			return []float32{}
+		} else if nullable {
+			return (*float32)(nil)
+		}
+
+		return float32(0)
+	case AttrTypeFloat64:
+		if array && nullable {
+			return (*[]float64)(nil)
+		} else if array {
+			return []float64{}
+		} else if nullable {
+			return (*float64)(nil)
+		}
+
+		return float64(0)
 	case AttrTypeBool:
 		if array && nullable {
 			return (*[]bool)(nil)

--- a/type.go
+++ b/type.go
@@ -29,7 +29,8 @@ import (
 //
 // An asterisk is present as a prefix if the type is nullable (like *string), brackets
 // if it is an array (e.g. []string). Nullable arrays combine asterisk and
-// brackets (e.g. *[]string). Byte arrays are represented using []uint8 (or *[]uint8).
+// brackets (e.g. *[]string). Byte arrays are represented by []uint8, which are output
+// as a base64 encoded string if the attribute type is equal to AttrTypeBytes.
 //
 // Developers are encouraged to use the constants, the Type struct, and other
 // tools to handle attribute types instead of dealing with strings.
@@ -243,7 +244,6 @@ func (a Attr) UnmarshalToType(data []byte) (interface{}, error) {
 		err error
 	)
 
-	// wenn data invalid ist, z.B. []byte("test") && AttrTypeInt16 => nil, error
 	switch a.Type {
 	case AttrTypeString:
 		if a.Array {

--- a/type.go
+++ b/type.go
@@ -226,8 +226,6 @@ func (t Type) Copy() Type {
 // types that are not supported by default.
 type TypeUnmarshaler interface {
 	GetZeroValue(array, nullable bool) interface{}
-	// CheckAttrType checks if the provided %T value is valid and if it's nullable and/or an array.
-	CheckAttrType(t string) (ok, array, nullable bool)
 	UnmarshalToType(data []byte, array, nullable bool) (interface{}, error)
 }
 

--- a/type.go
+++ b/type.go
@@ -928,3 +928,16 @@ func GetZeroValue(t int, array, nullable bool) interface{} {
 		return nil
 	}
 }
+
+func isNil(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+
+	switch reflect.TypeOf(v).Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+		return reflect.ValueOf(v).IsNil()
+	}
+
+	return false
+}

--- a/type_test.go
+++ b/type_test.go
@@ -305,9 +305,7 @@ func TestAttrUnmarshalToType(t *testing.T) {
 	// Invalid attribute type
 	attr.Type = AttrTypeInvalid
 	val, err = attr.UnmarshalToType([]byte("invalid"))
-	err2, ok := err.(Error)
-	assert.True(ok)
-	assert.IsType(Error{}, err2)
+	assert.Error(err)
 	assert.Nil(val)
 }
 

--- a/type_test.go
+++ b/type_test.go
@@ -3,6 +3,7 @@ package jsonapi_test
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -184,32 +185,36 @@ func TestAttrUnmarshalToType(t *testing.T) {
 	assert := assert.New(t)
 
 	var (
-		vstr    = "str"
-		vint    = int(1)
-		vint8   = int8(8)
-		vint16  = int16(16)
-		vint32  = int32(32)
-		vint64  = int64(64)
-		vuint   = uint(1)
-		vuint8  = uint8(8)
-		vuint16 = uint16(16)
-		vuint32 = uint32(32)
-		vuint64 = uint64(64)
-		vbool   = true
+		vstr     = "str"
+		vint     = int(1)
+		vint8    = int8(8)
+		vint16   = int16(16)
+		vint32   = int32(32)
+		vint64   = int64(64)
+		vuint    = uint(1)
+		vuint8   = uint8(8)
+		vuint16  = uint16(16)
+		vuint32  = uint32(32)
+		vuint64  = uint64(64)
+		vfloat32 = float32(math.MaxFloat32)
+		vfloat64 = math.MaxFloat64
+		vbool    = true
 
-		vstrarr    = []string{"str"}
-		vintarr    = []int{1}
-		vint8arr   = []int8{8}
-		vint16arr  = []int16{16}
-		vint32arr  = []int32{32}
-		vint64arr  = []int64{64}
-		vuintarr   = []uint{1}
-		vuint8arr  = []uint8{8}
-		vuint16arr = []uint16{16}
-		vuint32arr = []uint32{32}
-		vuint64arr = []uint64{64}
-		vboolarr   = []bool{true}
-		vtimearr   = []time.Time{{}}
+		vstrarr     = []string{"str"}
+		vintarr     = []int{1}
+		vint8arr    = []int8{8}
+		vint16arr   = []int16{16}
+		vint32arr   = []int32{32}
+		vint64arr   = []int64{64}
+		vuintarr    = []uint{1}
+		vuint8arr   = []uint8{8}
+		vuint16arr  = []uint16{16}
+		vuint32arr  = []uint32{32}
+		vuint64arr  = []uint64{64}
+		vfloat32arr = []float32{math.MaxFloat32}
+		vfloat64arr = []float64{math.MaxFloat64}
+		vboolarr    = []bool{true}
+		vtimearr    = []time.Time{{}}
 	)
 
 	tests := []struct {
@@ -240,36 +245,42 @@ func TestAttrUnmarshalToType(t *testing.T) {
 		{val: &vuint16},     // *uint16
 		{val: &vuint32},     // *uint32
 		{val: &vuint64},     // *uint64
+		{val: &vfloat32},    // *float32
+		{val: &vfloat64},    // *float64
 		{val: &vbool},       // *bool
 		{val: &time.Time{}}, // *time
 
-		{val: vstrarr},    // []string
-		{val: vintarr},    // []int
-		{val: vint8arr},   // []int8
-		{val: vint16arr},  // []int16
-		{val: vint32arr},  // []int32
-		{val: vint64arr},  // []int64
-		{val: vuintarr},   // []uint
-		{val: vuint8arr},  // []uint8
-		{val: vuint16arr}, // []uint16
-		{val: vuint32arr}, // []uint32
-		{val: vuint64arr}, // []uint64
-		{val: vboolarr},   // []bool
-		{val: vtimearr},   // []time.Time
+		{val: vstrarr},     // []string
+		{val: vintarr},     // []int
+		{val: vint8arr},    // []int8
+		{val: vint16arr},   // []int16
+		{val: vint32arr},   // []int32
+		{val: vint64arr},   // []int64
+		{val: vuintarr},    // []uint
+		{val: vuint8arr},   // []uint8
+		{val: vuint16arr},  // []uint16
+		{val: vuint32arr},  // []uint32
+		{val: vuint64arr},  // []uint64
+		{val: vfloat32arr}, // []float32
+		{val: vfloat64arr}, // []float64
+		{val: vboolarr},    // []bool
+		{val: vtimearr},    // []time.Time
 
-		{val: &vstrarr},    // *[]string
-		{val: &vintarr},    // *[]int
-		{val: &vint8arr},   // *[]int8
-		{val: &vint16arr},  // *[]int16
-		{val: &vint32arr},  // *[]int32
-		{val: &vint64arr},  // *[]int64
-		{val: &vuintarr},   // *[]uint
-		{val: &vuint8arr},  // *[]uint8
-		{val: &vuint16arr}, // *[]uint16
-		{val: &vuint32arr}, // *[]uint32
-		{val: &vuint64arr}, // *[]uint64
-		{val: &vboolarr},   // *[]bool
-		{val: &vtimearr},   // *[]time.Time
+		{val: &vstrarr},     // *[]string
+		{val: &vintarr},     // *[]int
+		{val: &vint8arr},    // *[]int8
+		{val: &vint16arr},   // *[]int16
+		{val: &vint32arr},   // *[]int32
+		{val: &vint64arr},   // *[]int64
+		{val: &vuintarr},    // *[]uint
+		{val: &vuint8arr},   // *[]uint8
+		{val: &vuint16arr},  // *[]uint16
+		{val: &vuint32arr},  // *[]uint32
+		{val: &vuint64arr},  // *[]uint64
+		{val: &vfloat32arr}, // *[]float32
+		{val: &vfloat64arr}, // *[]float64
+		{val: &vboolarr},    // *[]bool
+		{val: &vtimearr},    // *[]time.Time
 	}
 
 	attr := Attr{}
@@ -669,6 +680,54 @@ func TestGetAttrType(t *testing.T) {
 			nullable: true,
 		},
 		{
+			str:      "float32",
+			typ:      AttrTypeFloat32,
+			array:    false,
+			nullable: false,
+		},
+		{
+			str:      "[]float32",
+			typ:      AttrTypeFloat32,
+			array:    true,
+			nullable: false,
+		},
+		{
+			str:      "*float32",
+			typ:      AttrTypeFloat32,
+			array:    false,
+			nullable: true,
+		},
+		{
+			str:      "*[]float32",
+			typ:      AttrTypeFloat32,
+			array:    true,
+			nullable: true,
+		},
+		{
+			str:      "float64",
+			typ:      AttrTypeFloat64,
+			array:    false,
+			nullable: false,
+		},
+		{
+			str:      "[]float64",
+			typ:      AttrTypeFloat64,
+			array:    true,
+			nullable: false,
+		},
+		{
+			str:      "*float64",
+			typ:      AttrTypeFloat64,
+			array:    false,
+			nullable: true,
+		},
+		{
+			str:      "*[]float64",
+			typ:      AttrTypeFloat64,
+			array:    true,
+			nullable: true,
+		},
+		{
 			str:      "uint",
 			typ:      AttrTypeUint,
 			array:    false,
@@ -889,6 +948,8 @@ func TestGetAttrTypeString(t *testing.T) {
 	assert.Equal("uint16", GetAttrTypeString(AttrTypeUint16, false, false))
 	assert.Equal("uint32", GetAttrTypeString(AttrTypeUint32, false, false))
 	assert.Equal("uint64", GetAttrTypeString(AttrTypeUint64, false, false))
+	assert.Equal("float32", GetAttrTypeString(AttrTypeFloat32, false, false))
+	assert.Equal("float64", GetAttrTypeString(AttrTypeFloat64, false, false))
 	assert.Equal("bool", GetAttrTypeString(AttrTypeBool, false, false))
 	assert.Equal("time.Time", GetAttrTypeString(AttrTypeTime, false, false))
 
@@ -903,6 +964,8 @@ func TestGetAttrTypeString(t *testing.T) {
 	assert.Equal("*uint16", GetAttrTypeString(AttrTypeUint16, false, true))
 	assert.Equal("*uint32", GetAttrTypeString(AttrTypeUint32, false, true))
 	assert.Equal("*uint64", GetAttrTypeString(AttrTypeUint64, false, true))
+	assert.Equal("*float32", GetAttrTypeString(AttrTypeFloat32, false, true))
+	assert.Equal("*float64", GetAttrTypeString(AttrTypeFloat64, false, true))
 	assert.Equal("*bool", GetAttrTypeString(AttrTypeBool, false, true))
 	assert.Equal("*time.Time", GetAttrTypeString(AttrTypeTime, false, true))
 
@@ -917,6 +980,8 @@ func TestGetAttrTypeString(t *testing.T) {
 	assert.Equal("[]uint16", GetAttrTypeString(AttrTypeUint16, true, false))
 	assert.Equal("[]uint32", GetAttrTypeString(AttrTypeUint32, true, false))
 	assert.Equal("[]uint64", GetAttrTypeString(AttrTypeUint64, true, false))
+	assert.Equal("[]float32", GetAttrTypeString(AttrTypeFloat32, true, false))
+	assert.Equal("[]float64", GetAttrTypeString(AttrTypeFloat64, true, false))
 	assert.Equal("[]bool", GetAttrTypeString(AttrTypeBool, true, false))
 	assert.Equal("[]time.Time", GetAttrTypeString(AttrTypeTime, true, false))
 
@@ -931,6 +996,8 @@ func TestGetAttrTypeString(t *testing.T) {
 	assert.Equal("*[]uint16", GetAttrTypeString(AttrTypeUint16, true, true))
 	assert.Equal("*[]uint32", GetAttrTypeString(AttrTypeUint32, true, true))
 	assert.Equal("*[]uint64", GetAttrTypeString(AttrTypeUint64, true, true))
+	assert.Equal("*[]float32", GetAttrTypeString(AttrTypeFloat32, true, true))
+	assert.Equal("*[]float64", GetAttrTypeString(AttrTypeFloat64, true, true))
 	assert.Equal("*[]bool", GetAttrTypeString(AttrTypeBool, true, true))
 	assert.Equal("*[]time.Time", GetAttrTypeString(AttrTypeTime, true, true))
 
@@ -957,6 +1024,8 @@ func TestGetZeroValue(t *testing.T) {
 	assert.Equal(uint16(0), GetZeroValue(AttrTypeUint16, false, false))
 	assert.Equal(uint32(0), GetZeroValue(AttrTypeUint32, false, false))
 	assert.Equal(uint64(0), GetZeroValue(AttrTypeUint64, false, false))
+	assert.Equal(float32(0), GetZeroValue(AttrTypeFloat32, false, false))
+	assert.Equal(float64(0), GetZeroValue(AttrTypeFloat64, false, false))
 	assert.Equal(false, GetZeroValue(AttrTypeBool, false, false))
 	assert.Equal(time.Time{}, GetZeroValue(AttrTypeTime, false, false))
 
@@ -971,6 +1040,8 @@ func TestGetZeroValue(t *testing.T) {
 	assert.Equal([]uint16{}, GetZeroValue(AttrTypeUint16, true, false))
 	assert.Equal([]uint32{}, GetZeroValue(AttrTypeUint32, true, false))
 	assert.Equal([]uint64{}, GetZeroValue(AttrTypeUint64, true, false))
+	assert.Equal([]float32{}, GetZeroValue(AttrTypeFloat32, true, false))
+	assert.Equal([]float64{}, GetZeroValue(AttrTypeFloat64, true, false))
 	assert.Equal([]bool{}, GetZeroValue(AttrTypeBool, true, false))
 	assert.Equal([]time.Time{}, GetZeroValue(AttrTypeTime, true, false))
 
@@ -985,6 +1056,8 @@ func TestGetZeroValue(t *testing.T) {
 	assert.Equal(nilptr("uint16"), GetZeroValue(AttrTypeUint16, false, true))
 	assert.Equal(nilptr("uint32"), GetZeroValue(AttrTypeUint32, false, true))
 	assert.Equal(nilptr("uint64"), GetZeroValue(AttrTypeUint64, false, true))
+	assert.Equal(nilptr("float32"), GetZeroValue(AttrTypeFloat32, false, true))
+	assert.Equal(nilptr("float64"), GetZeroValue(AttrTypeFloat64, false, true))
 	assert.Equal(nilptr("bool"), GetZeroValue(AttrTypeBool, false, true))
 	assert.Equal(nilptr("time.Time"), GetZeroValue(AttrTypeTime, false, true))
 
@@ -999,6 +1072,8 @@ func TestGetZeroValue(t *testing.T) {
 	assert.Equal(nilptr("[]uint16"), GetZeroValue(AttrTypeUint16, true, true))
 	assert.Equal(nilptr("[]uint32"), GetZeroValue(AttrTypeUint32, true, true))
 	assert.Equal(nilptr("[]uint64"), GetZeroValue(AttrTypeUint64, true, true))
+	assert.Equal(nilptr("[]float32"), GetZeroValue(AttrTypeFloat32, true, true))
+	assert.Equal(nilptr("[]float64"), GetZeroValue(AttrTypeFloat64, true, true))
 	assert.Equal(nilptr("[]bool"), GetZeroValue(AttrTypeBool, true, true))
 	assert.Equal(nilptr("[]time.Time"), GetZeroValue(AttrTypeTime, true, true))
 

--- a/type_test.go
+++ b/type_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"reflect"
 	"testing"
 	"time"
 
@@ -23,6 +24,22 @@ func TestType_AddAttr(t *testing.T) {
 				Type:     AttrTypeString,
 				Nullable: false,
 			},
+		},
+		"attr string with type unmarshaler": {
+			attr: Attr{
+				Name:        "attr",
+				Type:        AttrTypeOther,
+				Unmarshaler: ReflectTypeUnmarshaler{Type: reflect.TypeOf("")},
+			},
+			err: false,
+		},
+		"attr other with type unmarshaler": {
+			attr: Attr{
+				Name:        "attr",
+				Type:        AttrTypeString,
+				Unmarshaler: ReflectTypeUnmarshaler{Type: reflect.TypeOf("")},
+			},
+			err: false,
 		},
 		"attr *string": {
 			attr: Attr{
@@ -53,6 +70,10 @@ func TestType_AddAttr(t *testing.T) {
 		},
 		"attr (no name)": {
 			attr: Attr{Type: AttrTypeBool},
+			err:  true,
+		},
+		"attr (no type unmarshaler)": {
+			attr: Attr{Type: AttrTypeOther},
 			err:  true,
 		},
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -58,48 +58,87 @@ func nilptr(t string) interface{} {
 	case "string":
 		var p *string
 		return p
+	case "[]string":
+		var p *[]string
+		return p
 	// Integers
 	case "int":
 		var p *int
 		return p
+	case "[]int":
+		var p *[]int
+		return p
 	case "int8":
 		var p *int8
+		return p
+	case "[]int8":
+		var p *[]int8
 		return p
 	case "int16":
 		var p *int16
 		return p
+	case "[]int16":
+		var p *[]int16
+		return p
 	case "int32":
 		var p *int32
+		return p
+	case "[]int32":
+		var p *[]int32
 		return p
 	case "int64":
 		var p *int64
 		return p
+	case "[]int64":
+		var p *[]int64
+		return p
 	case "uint":
 		var p *uint
+		return p
+	case "[]uint":
+		var p *[]uint
 		return p
 	case "uint8":
 		var p *uint8
 		return p
+	case "[]uint8":
+		var p *[]uint8
+		return p
 	case "uint16":
 		var p *uint16
+		return p
+	case "[]uint16":
+		var p *[]uint16
 		return p
 	case "uint32":
 		var p *uint32
 		return p
+	case "[]uint32":
+		var p *[]uint32
+		return p
 	case "uint64":
 		var p *uint64
+		return p
+	case "[]uint64":
+		var p *[]uint64
 		return p
 	// Bool
 	case "bool":
 		var p *bool
 		return p
+	case "[]bool":
+		var p *[]bool
+		return p
 	// time.Time
 	case "time.Time":
 		var p *time.Time
 		return p
+	case "[]time.Time":
+		var p *[]time.Time
+		return p
 	// []byte
 	case "[]byte":
-		var p *[]byte
+		var p *[]uint8
 		return p
 	default:
 		return nil

--- a/util_test.go
+++ b/util_test.go
@@ -122,6 +122,18 @@ func nilptr(t string) interface{} {
 	case "[]uint64":
 		var p *[]uint64
 		return p
+	case "float32":
+		var p *float32
+		return p
+	case "[]float32":
+		var p *[]float32
+		return p
+	case "float64":
+		var p *float64
+		return p
+	case "[]float64":
+		var p *[]float64
+		return p
 	// Bool
 	case "bool":
 		var p *bool

--- a/util_test.go
+++ b/util_test.go
@@ -101,7 +101,7 @@ func nilptr(t string) interface{} {
 	case "uint8":
 		var p *uint8
 		return p
-	case "[]uint8":
+	case "[]uint8", "[]byte":
 		var p *[]uint8
 		return p
 	case "uint16":
@@ -135,10 +135,6 @@ func nilptr(t string) interface{} {
 		return p
 	case "[]time.Time":
 		var p *[]time.Time
-		return p
-	// []byte
-	case "[]byte":
-		var p *[]uint8
 		return p
 	default:
 		return nil

--- a/wrapper.go
+++ b/wrapper.go
@@ -94,12 +94,12 @@ func Wrap(v interface{}) *Wrapper {
 					t = t.Elem()
 					null = true
 
-					if arrTag == "true" &&
+					if arrTag != "true" &&
 						(t.Kind() == reflect.Slice || t.Kind() == reflect.Array) {
 						t = t.Elem()
 						arr = true
 					}
-				} else if arrTag == "true" &&
+				} else if arrTag != "true" &&
 					(t.Kind() == reflect.Slice || t.Kind() == reflect.Array) {
 					t = t.Elem()
 					arr = true

--- a/wrapper.go
+++ b/wrapper.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 )
 
 // Wrapper wraps a reflect.Value that represents a struct.
@@ -14,13 +13,9 @@ import (
 // It implements the Resource interface, so the value can be handled as if it
 // were a Resource.
 type Wrapper struct {
-	val reflect.Value // Actual value (with content)
-
-	// Structure
-	typ   string
-	attrs map[string]Attr
-	rels  map[string]Rel
-	meta  Meta
+	val  reflect.Value // Actual value (with content)
+	typ  Type
+	meta Meta
 }
 
 // Wrap wraps v (a struct or a pointer to a struct) and returns a Wrapper that
@@ -33,14 +28,8 @@ type Wrapper struct {
 func Wrap(v interface{}) *Wrapper {
 	val := reflect.ValueOf(v)
 
-	switch {
-	case val.Kind() != reflect.Ptr:
-		if val.Kind() != reflect.Struct {
-			panic("value has to be a pointer to a struct")
-		}
-
+	if val.Kind() != reflect.Ptr {
 		newVal := reflect.New(val.Type()).Elem()
-
 		for i := 0; i < newVal.NumField(); i++ {
 			f := newVal.Field(i)
 			if f.CanSet() {
@@ -49,9 +38,7 @@ func Wrap(v interface{}) *Wrapper {
 		}
 
 		val = newVal
-	case val.Elem().Kind() != reflect.Struct:
-		panic("value has to be a pointer to a struct")
-	default:
+	} else {
 		val = val.Elem()
 	}
 
@@ -60,96 +47,15 @@ func Wrap(v interface{}) *Wrapper {
 		panic("invalid struct: " + err.Error())
 	}
 
+	typ, attrs, rels := getTypeInfo(val)
+
 	w := &Wrapper{
 		val: val,
-	}
-
-	// ID and type
-	_, w.typ = IDAndType(v)
-
-	// Attributes
-	w.attrs = map[string]Attr{}
-	for i := 0; i < w.val.NumField(); i++ {
-		fs := w.val.Type().Field(i)
-		jsonTag := fs.Tag.Get("json")
-		apiTag := fs.Tag.Get("api")
-		byteTag := fs.Tag.Get("bytes")
-		arrTag := fs.Tag.Get("array")
-
-		if apiTag == "attr" {
-			typ, arr, null := GetAttrType(fs.Type.String())
-			if typ == AttrTypeUint8 && arr && byteTag == "true" {
-				typ = AttrTypeBytes
-			}
-
-			// If the type is not handled by default, create a reflection based TypeUnmarshaler for
-			// this type.
-			var typU TypeUnmarshaler
-
-			if typ == AttrTypeInvalid {
-				typ = AttrTypeOther
-				t := fs.Type
-
-				if t.Kind() == reflect.Ptr {
-					t = t.Elem()
-					null = true
-
-					if arrTag != "true" &&
-						(t.Kind() == reflect.Slice || t.Kind() == reflect.Array) {
-						t = t.Elem()
-						arr = true
-					}
-				} else if arrTag != "true" &&
-					(t.Kind() == reflect.Slice || t.Kind() == reflect.Array) {
-					t = t.Elem()
-					arr = true
-					null = false
-				}
-
-				ru := ReflectTypeUnmarshaler{Type: t}
-				if fs.Type.Implements(reflect.TypeOf((*TypeUnmarshaler)(nil)).Elem()) {
-					typU = ru.GetZeroValue(false, false).(TypeUnmarshaler)
-				} else {
-					typU = ru
-				}
-			}
-
-			w.attrs[jsonTag] = Attr{
-				Name:        jsonTag,
-				Type:        typ,
-				Array:       arr,
-				Nullable:    null,
-				Unmarshaler: typU,
-			}
-		}
-	}
-
-	// Relationships
-	w.rels = map[string]Rel{}
-	for i := 0; i < w.val.NumField(); i++ {
-		fs := w.val.Type().Field(i)
-		jsonTag := fs.Tag.Get("json")
-		relTag := strings.Split(fs.Tag.Get("api"), ",")
-		invName := ""
-
-		if len(relTag) == 3 {
-			invName = relTag[2]
-		}
-
-		toOne := true
-		if fs.Type.String() == "[]string" {
-			toOne = false
-		}
-
-		if relTag[0] == "rel" {
-			w.rels[jsonTag] = Rel{
-				FromName: jsonTag,
-				ToType:   relTag[1],
-				ToOne:    toOne,
-				ToName:   invName,
-				FromType: w.typ,
-			}
-		}
+		typ: Type{
+			Name:  typ,
+			Attrs: attrs,
+			Rels:  rels,
+		},
 	}
 
 	// Meta
@@ -169,17 +75,17 @@ func (w *Wrapper) IDAndType() (string, string) {
 
 // Attrs returns the attributes of the Wrapper.
 func (w *Wrapper) Attrs() map[string]Attr {
-	return w.attrs
+	return w.typ.Attrs
 }
 
 // Rels returns the relationships of the Wrapper.
 func (w *Wrapper) Rels() map[string]Rel {
-	return w.rels
+	return w.typ.Rels
 }
 
 // Attr returns the attribute that corresponds to the given key.
 func (w *Wrapper) Attr(key string) Attr {
-	for _, attr := range w.attrs {
+	for _, attr := range w.typ.Attrs {
 		if attr.Name == key {
 			return attr
 		}
@@ -190,7 +96,7 @@ func (w *Wrapper) Attr(key string) Attr {
 
 // Rel returns the relationship that corresponds to the given key.
 func (w *Wrapper) Rel(key string) Rel {
-	for _, rel := range w.rels {
+	for _, rel := range w.typ.Rels {
 		if rel.FromName == key {
 			return rel
 		}
@@ -202,7 +108,6 @@ func (w *Wrapper) Rel(key string) Rel {
 // New returns a copy of the resource under the wrapper.
 func (w *Wrapper) New() Resource {
 	newVal := reflect.New(w.val.Type())
-
 	return Wrap(newVal.Interface())
 }
 
@@ -214,11 +119,7 @@ func (w *Wrapper) GetID() string {
 
 // GetType returns the wrapped resource's type.
 func (w *Wrapper) GetType() Type {
-	return Type{
-		Name:  w.typ,
-		Attrs: w.attrs,
-		Rels:  w.rels,
-	}
+	return w.typ
 }
 
 // Get returns the value associated to the attribute named after key.
@@ -290,7 +191,7 @@ func (w *Wrapper) getField(key string) interface{} {
 		sf := w.val.Type().Field(i)
 
 		if key == sf.Tag.Get("json") && sf.Tag.Get("api") != "" {
-			attr := w.attrs[key]
+			attr := w.typ.Attrs[key]
 
 			if (attr.Array || attr.Nullable) && field.IsNil() {
 				if attr.Unmarshaler != nil {

--- a/wrapper.go
+++ b/wrapper.go
@@ -74,10 +74,11 @@ func Wrap(v interface{}) *Wrapper {
 		apiTag := fs.Tag.Get("api")
 
 		if apiTag == "attr" {
-			typ, null := GetAttrType(fs.Type.String())
+			typ, arr, null := GetAttrType(fs.Type.String())
 			w.attrs[jsonTag] = Attr{
 				Name:     jsonTag,
 				Type:     typ,
+				Array:    arr,
 				Nullable: null,
 			}
 		}

--- a/wrapper.go
+++ b/wrapper.go
@@ -72,9 +72,14 @@ func Wrap(v interface{}) *Wrapper {
 		fs := w.val.Type().Field(i)
 		jsonTag := fs.Tag.Get("json")
 		apiTag := fs.Tag.Get("api")
+		byteTag := fs.Tag.Get("bytes")
 
 		if apiTag == "attr" {
 			typ, arr, null := GetAttrType(fs.Type.String())
+			if typ == AttrTypeUint8 && arr == true && byteTag == "true" {
+				typ = AttrTypeBytes
+			}
+
 			w.attrs[jsonTag] = Attr{
 				Name:     jsonTag,
 				Type:     typ,

--- a/wrapper.go
+++ b/wrapper.go
@@ -250,11 +250,14 @@ func (w *Wrapper) getField(key string) interface{} {
 		sf := w.val.Type().Field(i)
 
 		if key == sf.Tag.Get("json") && sf.Tag.Get("api") != "" {
-			if strings.HasPrefix(field.Type().String(), "*") && field.IsNil() {
-				return nil
+			typ, arr, null := GetAttrType(field.Type().String())
+			if typ != AttrTypeInvalid {
+				if (arr || null) && field.IsNil() {
+					zv := GetZeroValue(typ, arr, null)
+					return zv
+				}
+				return field.Interface()
 			}
-
-			return field.Interface()
 		}
 	}
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -76,7 +76,7 @@ func Wrap(v interface{}) *Wrapper {
 
 		if apiTag == "attr" {
 			typ, arr, null := GetAttrType(fs.Type.String())
-			if typ == AttrTypeUint8 && arr == true && byteTag == "true" {
+			if typ == AttrTypeUint8 && arr && byteTag == "true" {
 				typ = AttrTypeBytes
 			}
 
@@ -261,6 +261,7 @@ func (w *Wrapper) getField(key string) interface{} {
 					zv := GetZeroValue(typ, arr, null)
 					return zv
 				}
+
 				return field.Interface()
 			}
 		}

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -206,20 +206,11 @@ func TestWrapper(t *testing.T) {
 	assert.Equal(&newInt, wrap2.Get("intptr"), "set int pointer attribute")
 
 	wrap2.Set("uintptr", nil)
+	assert.Equal((*uint)(nil), wrap2.Get("uintptr"))
+	assert.NotEqual(nil, wrap2.Get("uintptr"))
 
-	if wrap2.Get("uintptr") != nil {
-		// We first do a != nil check because that's what we are really
-		// checking and reflect.DeepEqual doesn't work exactly work the same
-		// way. If the nil check fails, then the next line will fail too.
-		assert.Equal("nil pointer", nil, wrap2.Get("uintptr"))
-	}
-
-	if res2.UintPtr != nil {
-		// We first do a != nil check because that's what we are really
-		// checking and reflect.DeepEqual doesn't work exactly work the same
-		// way. If the nil check fails, then the next line will fail too.
-		assert.Equal("nil pointer 2", nil, res2.UintPtr)
-	}
+	assert.Equal((*uint)(nil), res2.UintPtr)
+	assert.NotEqual(nil, res2.UintPtr)
 
 	// New
 	wrap3 := wrap1.New()
@@ -250,6 +241,37 @@ func TestWrapper(t *testing.T) {
 		wrap3.Get("str"),
 		"modified value does not affect original",
 	)
+
+	res4 := &mockType4{
+		BoolArr: []bool{true, false},
+	}
+	wrap4 := Wrap(res4)
+
+	assert.Equal([]bool{true, false}, wrap4.Get("boolarr"))
+	assert.Equal([]uint{}, wrap4.Get("uintarr"))
+
+	res5 := &mockType5{
+		BoolArrPtr: &[]bool{true, false},
+	}
+	wrap5 := Wrap(res5)
+
+	assert.Equal(&[]bool{true, false}, res5.BoolArrPtr)
+	assert.Equal(res5.BoolArrPtr, wrap5.Get("boolarrptr"))
+
+	assert.Equal((*[]uint)(nil), res5.UintArrPtr)
+	assert.Equal(res5.UintArrPtr, wrap5.Get("uintarrptr"))
+
+	wrap5.Set("boolarrptr", nil)
+	assert.Equal((*[]bool)(nil), res5.BoolArrPtr)
+	assert.Equal(res5.BoolArrPtr, wrap5.Get("boolarrptr"))
+
+	wrap5.Set("strarrptr", &[]string{"foo", "bar"})
+	assert.Equal(&[]string{"foo", "bar"}, res5.StrArrPtr)
+	assert.Equal(res5.StrArrPtr, wrap5.Get("strarrptr"))
+
+	wrap5.Set("strarrptr", (*[]string)(nil))
+	assert.Equal((*[]string)(nil), res5.StrArrPtr)
+	assert.Equal(res5.StrArrPtr, wrap5.Get("strarrptr"))
 }
 
 func TestWrapperSet(t *testing.T) {

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -354,6 +354,7 @@ func TestWrapperSet(t *testing.T) {
 		assert.Equal("", res.Get("str"))
 		assert.Equal((*string)(nil), res.Get("strPtr"))
 		assert.Equal([]string{}, res.Get("strArr"))
+		assert.Equal([][]float32{}, res.Get("float32Matrix"))
 		assert.Equal((*[]string)(nil), res.Get("strPtrArr"))
 
 		assert.Equal(testObjType{}, res.Get("obj"))

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -69,6 +69,37 @@ func TestWrapStruct(t *testing.T) {
 	res1.Str = "new_string"
 	assert.NotEqual(res1.Str, wrap1.Get("str"), "str field")
 	assert.Equal("another_string", wrap1.Get("str"), "str field")
+
+	res2 := mockType6{
+		ID:        "id1",
+		Obj:       testObjType{Prop1: "abc"},
+		ObjPtr:    &testObjType{Prop2: "def"},
+		ObjArr:    []testObjType{{Prop1: "abc"}},
+		ObjArrPtr: &[]testObjType{{Prop1: "def"}},
+	}
+
+	wrap2 := Wrap(res2)
+
+	// ID, type, field
+	id, typ = wrap2.IDAndType()
+	assert.Equal(res2.ID, id, "id")
+	assert.Equal("mocktype6", typ, "type")
+	assert.Equal(res2.Str, wrap2.Get("str"), "str field")
+
+	// Modifying the wrapper does not modify the original value.
+	wrap2.SetID("another_id")
+
+	id, _ = wrap1.IDAndType()
+	assert.Equal("another_id", id, "type")
+
+	wrap2.Set("obj", testObjType{Prop1: "xyz"})
+	assert.Equal(testObjType{Prop1: "xyz"}, wrap2.Get("obj"), "obj field")
+	assert.NotEqual(res2.Obj, wrap2.Get("obj"), "obj field")
+
+	// Modifying the original value does not modify the wrapper.
+	res2.ObjPtr = &testObjType{Prop1: "xyz"}
+	assert.NotEqual(res2.ObjPtr, wrap2.Get("objPtr"), "objPtr field")
+	assert.Equal(&testObjType{Prop2: "def"}, wrap2.Get("objPtr"), "objPtr field")
 }
 
 func TestWrapper(t *testing.T) {
@@ -315,6 +346,38 @@ func TestWrapperSet(t *testing.T) {
 			assert.EqualValues(test.val, res1.Get(test.field))
 		}
 	}
+
+	t.Run("custom type unmarshaler", func(t *testing.T) {
+		res := Wrap(&mockType6{})
+		assert.NotNil(res)
+
+		assert.Equal("", res.Get("str"))
+		assert.Equal((*string)(nil), res.Get("strPtr"))
+		assert.Equal([]string{}, res.Get("strArr"))
+		assert.Equal((*[]string)(nil), res.Get("strPtrArr"))
+
+		assert.Equal(testObjType{}, res.Get("obj"))
+		assert.Equal((*testObjType)(nil), res.Get("objPtr"))
+		assert.Equal([]testObjType{}, res.Get("objArr"))
+		assert.Equal((*[]testObjType)(nil), res.Get("objArrPtr"))
+
+		obj := testObjType{Prop1: "foo", Prop2: "bar", Prop3: "baz"}
+		objPtr := &testObjType{Prop1: "foo", Prop2: "bar", Prop3: "baz"}
+		objArr := []testObjType{{Prop1: "foo", Prop2: "bar", Prop3: "baz"}}
+		objArrPtr := &[]testObjType{{Prop1: "foo", Prop2: "bar", Prop3: "baz"}}
+
+		res.Set("obj", obj)
+		assert.Equal(obj, res.Get("obj"))
+
+		res.Set("objPtr", objPtr)
+		assert.Equal(objPtr, res.Get("objPtr"))
+
+		res.Set("objArr", objArr)
+		assert.Equal(objArr, res.Get("objArr"))
+
+		res.Set("objArrPtr", objArrPtr)
+		assert.Equal(objArrPtr, res.Get("objArrPtr"))
+	})
 }
 
 func TestWrapperGetAndSetErrors(t *testing.T) {
@@ -346,5 +409,360 @@ func TestWrapperGetAndSetErrors(t *testing.T) {
 	// Set with value of wrong type
 	assert.Panics(func() {
 		wrap.Set("str", 42)
+	})
+}
+
+func TestReflectTypeUnmarshaler_GetZeroValue(t *testing.T) {
+	tests := []struct {
+		Name      string
+		Type      reflect.Type
+		Array     bool
+		Nullable  bool
+		ZeroValue interface{}
+	}{
+		{
+			Name: "str",
+			Type: reflect.TypeOf(""),
+
+			ZeroValue: "",
+		},
+		{
+			Name: "str arr",
+			Type: reflect.TypeOf(""),
+
+			Array:     true,
+			ZeroValue: []string{},
+		},
+		{
+			Name: "str ptr",
+			Type: reflect.TypeOf(""),
+
+			Nullable:  true,
+			ZeroValue: (*string)(nil),
+		},
+		{
+			Name: "str array ptr",
+			Type: reflect.TypeOf(""),
+
+			Array:     true,
+			Nullable:  true,
+			ZeroValue: (*[]string)(nil),
+		},
+		{
+			Name: "str arr",
+			Type: reflect.TypeOf([]string{}),
+
+			ZeroValue: []string{},
+		},
+		{
+			Name: "str arr arr",
+			Type: reflect.TypeOf([]string{}),
+
+			Array:     true,
+			ZeroValue: [][]string{},
+		},
+		{
+			Name: "str arr ptr",
+			Type: reflect.TypeOf([]string{}),
+
+			Nullable:  true,
+			ZeroValue: (*[]string)(nil),
+		},
+		{
+			Name: "str arr arr ptr",
+			Type: reflect.TypeOf([]string{}),
+
+			Array:     true,
+			Nullable:  true,
+			ZeroValue: (*[][]string)(nil),
+		},
+		{
+			Name: "testObjType",
+			Type: reflect.TypeOf(testObjType{}),
+
+			ZeroValue: testObjType{},
+		},
+		{
+			Name: "testObjType arr",
+			Type: reflect.TypeOf(testObjType{}),
+
+			Array:     true,
+			ZeroValue: []testObjType{},
+		},
+		{
+			Name: "testObjType ptr",
+			Type: reflect.TypeOf(testObjType{}),
+
+			Nullable:  true,
+			ZeroValue: (*testObjType)(nil),
+		},
+		{
+			Name: "testObjType array ptr",
+			Type: reflect.TypeOf(testObjType{}),
+
+			Array:     true,
+			Nullable:  true,
+			ZeroValue: (*[]testObjType)(nil),
+		},
+		{
+			Name: "anon struct",
+			Type: reflect.TypeOf(struct {
+				Prop string
+			}{}),
+
+			ZeroValue: struct {
+				Prop string
+			}{},
+		},
+		{
+			Name: "anon struct arr",
+			Type: reflect.TypeOf(struct {
+				Prop string
+			}{}),
+
+			Array: true,
+			ZeroValue: []struct {
+				Prop string
+			}{},
+		},
+		{
+			Name: "anon struct ptr",
+			Type: reflect.TypeOf(struct {
+				Prop string
+			}{}),
+
+			Nullable: true,
+			ZeroValue: (*struct {
+				Prop string
+			})(nil),
+		},
+		{
+			Name: "anon struct array ptr",
+			Type: reflect.TypeOf(struct {
+				Prop string
+			}{}),
+
+			Array:    true,
+			Nullable: true,
+			ZeroValue: (*[]struct {
+				Prop string
+			})(nil),
+		},
+		{
+			Name: "map",
+			Type: reflect.TypeOf(map[string]string{}),
+
+			Array:     false,
+			Nullable:  false,
+			ZeroValue: map[string]string{},
+		},
+		{
+			Name: "map array",
+			Type: reflect.TypeOf(map[string]string{}),
+
+			Array:     true,
+			Nullable:  false,
+			ZeroValue: []map[string]string{},
+		},
+		{
+			Name: "map ptr",
+			Type: reflect.TypeOf(map[string]string{}),
+
+			Array:     false,
+			Nullable:  true,
+			ZeroValue: (*map[string]string)(nil),
+		},
+		{
+			Name: "map array ptr",
+			Type: reflect.TypeOf(map[string]string{}),
+
+			Array:     true,
+			Nullable:  true,
+			ZeroValue: (*[]map[string]string)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			ru := ReflectTypeUnmarshaler{Type: test.Type}
+			assert.Equal(t, test.ZeroValue, ru.GetZeroValue(test.Array, test.Nullable))
+		})
+	}
+}
+
+func TestReflectTypeUnmarshaler_UnmarshalToType(t *testing.T) {
+	str := "test! äöü"
+
+	tests := []struct {
+		Name     string
+		Type     reflect.Type
+		Array    bool
+		Nullable bool
+		Data     []byte
+		Value    interface{}
+	}{
+		{
+			Name: "str",
+			Type: reflect.TypeOf(""),
+
+			Data:  []byte("\"foo\""),
+			Value: "foo",
+		},
+		{
+			Name: "str empty",
+			Type: reflect.TypeOf(""),
+
+			Data:  []byte("\"\""),
+			Value: "",
+		},
+		{
+			Name: "str array",
+			Type: reflect.TypeOf(""),
+
+			Array: true,
+			Data:  []byte("[\"foo\"]"),
+			Value: []string{"foo"},
+		},
+		{
+			Name: "str empty array",
+			Type: reflect.TypeOf(""),
+
+			Array: true,
+			Data:  []byte("[]"),
+			Value: []string{},
+		},
+		{
+			Name: "str ptr null",
+			Type: reflect.TypeOf(""),
+
+			Nullable: true,
+			Data:     []byte("null"),
+			Value:    (*string)(nil),
+		},
+		{
+			Name: "str ptr",
+			Type: reflect.TypeOf(""),
+
+			Nullable: true,
+			Data:     []byte("\"test! äöü\""),
+			Value:    &str,
+		},
+		{
+			Type: reflect.TypeOf(""),
+
+			Name:     "str array ptr null",
+			Array:    true,
+			Nullable: true,
+			Data:     []byte("null"),
+			Value:    (*[]string)(nil),
+		},
+		{
+			Name: "str arr ptr",
+			Type: reflect.TypeOf(""),
+
+			Array:    true,
+			Nullable: true,
+			Data:     []byte("[\"abc\",\"def\"]"),
+			Value:    &[]string{"abc", "def"},
+		},
+		{
+			Name: "2d string matrix empty",
+			Type: reflect.TypeOf(([][]string)(nil)),
+
+			Data:  []byte("[]"),
+			Value: [][]string{},
+		},
+		{
+			Name: "2d string matrix",
+			Type: reflect.TypeOf(([][]string)(nil)),
+
+			Data:  []byte("[[\"abc\"],[\"abc\",\"def\"]]"),
+			Value: [][]string{{"abc"}, {"abc", "def"}},
+		},
+		{
+			Name: "2d string matrix array ptr",
+			Type: reflect.TypeOf(([][]string)(nil)),
+
+			Array:    true,
+			Nullable: true,
+			Data:     []byte("[[[\"abc\"],[\"abc\",\"def\"]]]"),
+			Value:    &[][][]string{{{"abc"}, {"abc", "def"}}},
+		},
+		{
+			Name: "map",
+			Type: reflect.TypeOf(map[string]string{}),
+
+			Data:  []byte("{\"foo\":\"bar\"}"),
+			Value: map[string]string{"foo": "bar"},
+		},
+		{
+			Name: "map array",
+			Type: reflect.TypeOf(map[string]string{}),
+
+			Array: true,
+			Data:  []byte("[{\"foo\":\"bar\"}]"),
+			Value: []map[string]string{{"foo": "bar"}},
+		},
+		{
+			Name: "map nullable array",
+			Type: reflect.TypeOf(map[string]string{}),
+
+			Array:    true,
+			Nullable: true,
+			Data:     []byte("null"),
+			Value:    (*[]map[string]string)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			ru := ReflectTypeUnmarshaler{Type: test.Type}
+			v, e := ru.UnmarshalToType(test.Data, test.Array, test.Nullable)
+
+			assert.NoError(t, e)
+			assert.Equal(t, test.Value, v)
+		})
+	}
+
+	t.Run("errors", func(t *testing.T) {
+		ru := ReflectTypeUnmarshaler{Type: reflect.TypeOf((*[]string)(nil))}
+
+		v, err := ru.UnmarshalToType(nil, false, false)
+		assert.Nil(t, v)
+		assert.Error(t, err)
+
+		v, err = ru.UnmarshalToType(nil, false, true)
+		assert.Nil(t, v)
+		assert.Error(t, err)
+
+		v, err = ru.UnmarshalToType([]byte("null"), false, false)
+		assert.Nil(t, v)
+		assert.Error(t, err)
+
+		v, err = ru.UnmarshalToType([]byte("null"), true, false)
+		assert.Nil(t, v)
+		assert.Error(t, err)
+
+		ru = ReflectTypeUnmarshaler{Type: reflect.TypeOf((*[]testObjType)(nil))}
+
+		v, err = ru.UnmarshalToType(nil, false, false)
+		assert.Nil(t, v)
+		assert.Error(t, err)
+
+		v, err = ru.UnmarshalToType(nil, false, true)
+		assert.Nil(t, v)
+		assert.Error(t, err)
+
+		v, err = ru.UnmarshalToType([]byte("null"), false, false)
+		assert.Nil(t, v)
+		assert.Error(t, err)
+
+		v, err = ru.UnmarshalToType([]byte("null"), true, false)
+		assert.Nil(t, v)
+		assert.Error(t, err)
+
+		v, err = ru.UnmarshalToType([]byte("\"test\""), true, false)
+		assert.Nil(t, v)
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
A major update that extends the existing range of usable attribute types to become more compatible with the [allowed attribute types](https://jsonapi.org/format/#document-resource-object-attributes) of the JSON:API specification.
#### Attr
The `Attr`-Struct has been extended with an `Array` property, which allows to represent any supported attribute type as a (nullable) array. 

#### New types
* `AttrTypeFloat32` and `AttrTypeFloat64` were added as types, allowing the use of `float32` and `float64` properties. 
* `[]byte`/`[]uint8` can be formatted as literal uint8 arrays in addition to the previous format as base64 encoded strings.
  * `AttrTypeBytes` => base64 encoded string
  * `AttrTypeUint8` (`Array = true`) => array
  * For the `Wrap` function to work correctly, a new tag has been added (`bytes: "true"`), which must be added to the struct property.

#### Support for custom data types
This PR also brings support for arbitrary data types like maps, structs, matrices etc. Check the comments to better understand how this works.

All changes are supported by prototyping/quick start features like `Wrapper` and `BuildType`.