### PR TITLE
Improve Links-member usage

### DIFF
--- a/document.go
+++ b/document.go
@@ -173,6 +173,7 @@ func MarshalDocument(doc *Document, url *URL) ([]byte, error) {
 	if len(links) > 0 {
 		plMap["links"] = links
 	}
+
 	plMap["jsonapi"] = map[string]string{"version": "1.0"}
 
 	return json.Marshal(plMap)

--- a/document.go
+++ b/document.go
@@ -159,18 +159,19 @@ func MarshalDocument(doc *Document, url *URL) ([]byte, error) {
 		plMap["meta"] = doc.Meta
 	}
 
-	links := map[string]Link{}
-	if len(doc.Links) > 0 {
-		links = doc.Links
-	}
+	links := doc.Links
 
 	if url != nil {
+		if links == nil {
+			links = map[string]Link{}
+		}
+
 		links["self"] = Link{
 			HRef: doc.PrePath + url.String(),
 		}
 	}
 
-	if len(links) > 0 {
+	if links != nil {
 		plMap["links"] = links
 	}
 

--- a/document.go
+++ b/document.go
@@ -109,10 +109,10 @@ func MarshalDocument(doc *Document, url *URL) ([]byte, error) {
 	}
 
 	// Data
-	var errors json.RawMessage
+	var errs json.RawMessage
 	if len(doc.Errors) > 0 {
 		// Errors
-		errors, err = json.Marshal(doc.Errors)
+		errs, err = json.Marshal(doc.Errors)
 	}
 
 	if err != nil {
@@ -145,8 +145,8 @@ func MarshalDocument(doc *Document, url *URL) ([]byte, error) {
 	// Marshaling
 	plMap := map[string]interface{}{}
 
-	if len(errors) > 0 {
-		plMap["errors"] = errors
+	if len(errs) > 0 {
+		plMap["errors"] = errs
 	} else if len(data) > 0 {
 		plMap["data"] = data
 
@@ -159,12 +159,20 @@ func MarshalDocument(doc *Document, url *URL) ([]byte, error) {
 		plMap["meta"] = doc.Meta
 	}
 
+	links := map[string]Link{}
+	if len(doc.Links) > 0 {
+		links = doc.Links
+	}
+
 	if url != nil {
-		plMap["links"] = map[string]string{
-			"self": doc.PrePath + url.String(),
+		links["self"] = Link{
+			HRef: doc.PrePath + url.String(),
 		}
 	}
 
+	if len(links) > 0 {
+		plMap["links"] = links
+	}
 	plMap["jsonapi"] = map[string]string{"version": "1.0"}
 
 	return json.Marshal(plMap)

--- a/document_test.go
+++ b/document_test.go
@@ -257,7 +257,13 @@ func TestMarshalDocument(t *testing.T) {
 				},
 				PrePath: "https://example.org",
 				Links: map[string]Link{
-					"foo": {HRef: "https://example.org/bar", Meta: map[string]interface{}{"foo": "bar", "bar": "baz"}},
+					"foo": {
+						HRef: "https://example.org/bar",
+						Meta: map[string]interface{}{
+							"foo": "bar",
+							"bar": "baz",
+						},
+					},
 				},
 			},
 			fields: []string{

--- a/document_test.go
+++ b/document_test.go
@@ -90,6 +90,62 @@ func TestInclude(t *testing.T) {
 	assert.Equal(expect, ids)
 }
 
+func TestMarshalDocumentLinks(t *testing.T) {
+	tests := map[string]struct {
+		doc *Document
+		url *URL
+	}{
+		"resource with links": {
+			doc: &Document{
+				Data: &mockTypeImpl{
+					ID:  "id1",
+					Str: "str",
+					Int: 12,
+					ToX: []string{
+						"id2",
+						"id3",
+					},
+					To1: "id5",
+					links: map[string]Link{
+						"test": {HRef: "https://example.org/test"},
+					},
+					meta: map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+				RelData: map[string][]string{
+					"mockTypeImpl": {"to-x", "to-1"},
+				},
+			},
+			url: &URL{
+				Fragments: []string{"fake", "path"},
+				Params: &Params{
+					Fields: map[string][]string{"mockTypeImpl": {"str", "int", "to-x", "to-1"}},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Marshaling
+			payload, err := MarshalDocument(test.doc, test.url)
+			assert.NoError(err)
+
+			// Golden file
+			filename := strings.ReplaceAll(name, " ", "_") + ".json"
+			path := filepath.Join("testdata", "goldenfiles", "marshaling", filename)
+
+			// Retrieve the expected result from file
+			expected, _ := ioutil.ReadFile(path)
+			assert.NoError(err, name)
+			assert.JSONEq(string(expected), string(payload))
+		})
+	}
+}
+
 func TestMarshalDocument(t *testing.T) {
 	// TODO Describe how this test suite works
 	// Setup

--- a/document_test.go
+++ b/document_test.go
@@ -153,6 +153,17 @@ func TestMarshalDocument(t *testing.T) {
 				PrePath: "https://example.org",
 			},
 		}, {
+			name: "empty data with links",
+			doc: &Document{
+				PrePath: "https://example.org",
+				Links: map[string]Link{
+					"foo": {HRef: "https://example.org/bar", Meta: map[string]interface{}{
+						"last_accessed": "5 minutes ago",
+					}},
+					"bar": {HRef: "https://example.org/baz"},
+				},
+			},
+		}, {
 			name: "empty collection",
 			doc: &Document{
 				Data: &Resources{},
@@ -177,6 +188,21 @@ func TestMarshalDocument(t *testing.T) {
 					"mocktype": {"to-1", "to-x-from-1"},
 				},
 				PrePath: "https://example.org",
+			},
+			fields: []string{
+				"str", "uint64", "bool", "int", "time", "to-1", "to-x-from-1",
+			},
+		}, {
+			name: "collection with links",
+			doc: &Document{
+				Data: Range(col, nil, nil, []string{}, 10, 0),
+				RelData: map[string][]string{
+					"mocktype": {"to-1", "to-x-from-1"},
+				},
+				PrePath: "https://example.org",
+				Links: map[string]Link{
+					"foo": {HRef: "https://example.org/bar", Meta: map[string]interface{}{"foo": "bar", "bar": "baz"}},
+				},
 			},
 			fields: []string{
 				"str", "uint64", "bool", "int", "time", "to-1", "to-x-from-1",

--- a/error.go
+++ b/error.go
@@ -14,7 +14,7 @@ type Error struct {
 	Status string                 `json:"status"`
 	Title  string                 `json:"title"`
 	Detail string                 `json:"detail"`
-	Links  map[string]string      `json:"links"`
+	Links  map[string]Link        `json:"links"`
 	Source map[string]interface{} `json:"source"`
 	Meta   Meta                   `json:"meta"`
 }
@@ -22,7 +22,7 @@ type Error struct {
 // NewError returns an empty Error object.
 func NewError() Error {
 	err := Error{
-		Links:  map[string]string{},
+		Links:  map[string]Link{},
 		Source: map[string]interface{}{},
 		Meta:   Meta{},
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -309,8 +309,16 @@ func TestErrorMarshalJSON(t *testing.T) {
 		Status: "Status",
 		Title:  "Title",
 		Detail: "Detail",
-		Links: map[string]string{
-			"link": "http://example.com",
+		Links: map[string]Link{
+			"link": {
+				HRef: "https://example.com",
+			},
+			"about": {
+				HRef: "https://example.com",
+				Meta: map[string]interface{}{
+					"abc": "def",
+				},
+			},
 		},
 		Source: map[string]interface{}{
 			"parameter": "param",
@@ -329,7 +337,13 @@ func TestErrorMarshalJSON(t *testing.T) {
 			"detail": "Detail",
 			"id": "c1897530-fdf5-4a42-88fb-1c1c4bd0962f",
 			"links": {
-				"link": "http://example.com"
+				"link": "https://example.com",
+				"about": {
+					"href": "https://example.com",
+					"meta": {
+						"abc": "def"					
+					}
+				}
 			},
 			"meta": {
 				"meta": 123

--- a/identifiers.go
+++ b/identifiers.go
@@ -36,10 +36,25 @@ func (i Identifiers) IDs() []string {
 	return ids
 }
 
-// Identifier represents a resource's type and ID.
+// Identifier represents the type, ID and metadata of a resource.
 type Identifier struct {
 	ID   string `json:"id"`
 	Type string `json:"type"`
+	Meta Meta   `json:"meta,omitempty"`
+}
+
+// RelData contains information about a to-one relationship, including links and metadata.
+type RelData struct {
+	Res   Identifier
+	Links map[string]Link
+	Meta  Meta
+}
+
+// RelDataMany contains information about a to-many relationship, including links and metadata.
+type RelDataMany struct {
+	Res   Identifiers
+	Links map[string]Link
+	Meta  Meta
 }
 
 // UnmarshalIdentifier reads a payload where the main data is one identifier to

--- a/identifiers_test.go
+++ b/identifiers_test.go
@@ -48,6 +48,25 @@ func TestUnmarshalIdentifiers(t *testing.T) {
 		assert.Equal(iden, iden2)
 	})
 
+	t.Run("identifier with metadata", func(t *testing.T) {
+		assert := assert.New(t)
+
+		iden := Identifier{
+			ID:   "id2",
+			Type: "mocktype",
+			Meta: map[string]interface{}{
+				"key1": "value1",
+			},
+		}
+
+		payload, err := json.Marshal(iden)
+		assert.NoError(err)
+
+		iden2, err := UnmarshalIdentifier(payload, schema)
+		assert.NoError(err)
+		assert.Equal(iden, iden2)
+	})
+
 	t.Run("identifier without ID", func(t *testing.T) {
 		assert := assert.New(t)
 

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -44,7 +44,8 @@ type mocktype struct {
 	ToXFrom1 []string `json:"to-x-from-1" api:"rel,mocktype,to-1-from-x"`
 	ToXFromX []string `json:"to-x-from-x" api:"rel,mocktype,to-x-from-x"`
 
-	meta Meta
+	meta  Meta
+	links map[string]Link
 }
 
 func (mt *mocktype) Meta() Meta {
@@ -53,4 +54,127 @@ func (mt *mocktype) Meta() Meta {
 
 func (mt *mocktype) SetMeta(m Meta) {
 	mt.meta = m
+}
+
+type mockTypeImpl struct {
+	ID string `json:"id" api:"mockTypeImpl"`
+
+	// Attributes
+	Str string `json:"str" api:"attr"`
+	Int int    `json:"int" api:"attr"`
+
+	To1 string   `json:"to-1" api:"rel,mockTypeImpl"`
+	ToX []string `json:"to-x" api:"rel,mockTypeImpl"`
+
+	meta  Meta
+	links map[string]Link
+}
+
+func (mt mockTypeImpl) Attrs() map[string]Attr {
+	return map[string]Attr{
+		"str": {
+			Name: "str",
+			Type: AttrTypeString,
+		},
+		"int": {
+			Name: "int",
+			Type: AttrTypeInt,
+		},
+	}
+}
+
+func (mt mockTypeImpl) Rels() map[string]Rel {
+	return map[string]Rel{
+		"to-x": {
+			FromName: "to-x",
+			ToType:   "mockTypeImpl",
+			FromType: "mockTypeImpl",
+		},
+		"to-1": {
+			FromName: "to-1",
+			ToType:   "mockTypeImpl",
+			ToOne:    true,
+			FromType: "mockTypeImpl",
+		},
+	}
+}
+
+func (mt mockTypeImpl) GetType() Type {
+	return Type{
+		Name:  "mockTypeImpl",
+		Attrs: mt.Attrs(),
+		Rels:  mt.Rels(),
+		NewFunc: func() Resource {
+			return &mockTypeImpl{}
+		},
+	}
+}
+
+func (mt mockTypeImpl) Get(key string) interface{} {
+	switch key {
+	case "id":
+		return mt.ID
+	case "str":
+		return mt.Str
+	case "int":
+		return mt.Int
+	// rels
+	case "to-x":
+		return RelDataMany{
+			Res: Identifiers{
+				{ID: mt.ToX[1], Meta: Meta{"key1": "value1"}},
+				{ID: mt.ToX[0]},
+			},
+			Links: map[string]Link{
+				"example": {HRef: "https://example.org"},
+			},
+			Meta: Meta{
+				"test": "ok",
+			},
+		}
+	case "to-1":
+		return RelData{
+			Res: Identifier{ID: mt.To1, Meta: map[string]interface{}{
+				"k2": "v2",
+			}},
+			Links: map[string]Link{
+				"l1": {HRef: "https://example.org/l1"},
+			},
+			Meta: Meta{
+				"k1": "v1",
+			},
+		}
+	}
+	return nil
+}
+
+func (mt *mockTypeImpl) Set(key string, val interface{}) {
+	switch key {
+	case "id":
+		mt.ID = val.(string)
+	case "str":
+		mt.Str = val.(string)
+	case "int":
+		mt.Int = val.(int)
+	case "to-x":
+		mt.ToX = val.([]string)
+	case "to-1":
+		mt.To1 = val.(string)
+	}
+}
+
+func (mt *mockTypeImpl) Meta() Meta {
+	return mt.meta
+}
+
+func (mt *mockTypeImpl) SetMeta(meta Meta) {
+	mt.meta = meta
+}
+
+func (mt *mockTypeImpl) Links() map[string]Link {
+	return mt.links
+}
+
+func (mt *mockTypeImpl) SetLinks(links map[string]Link) {
+	mt.links = links
 }

--- a/jsonapi_test.go
+++ b/jsonapi_test.go
@@ -56,6 +56,14 @@ func (mt *mocktype) SetMeta(m Meta) {
 	mt.meta = m
 }
 
+func (mt *mocktype) Links() map[string]Link {
+	return mt.links
+}
+
+func (mt *mocktype) SetLinks(links map[string]Link) {
+	mt.links = links
+}
+
 type mockTypeImpl struct {
 	ID string `json:"id" api:"mockTypeImpl"`
 
@@ -145,6 +153,7 @@ func (mt mockTypeImpl) Get(key string) interface{} {
 			},
 		}
 	}
+
 	return nil
 }
 

--- a/link.go
+++ b/link.go
@@ -60,9 +60,9 @@ func buildSelfLink(res Resource, prepath string) string {
 
 // buildRelationshipLinks builds a links object (according to the JSON:API
 // specification) that include both the self and related members.
-func buildRelationshipLinks(res Resource, prepath, rel string) map[string]string {
-	return map[string]string{
-		"self":    buildSelfLink(res, prepath) + "/relationships/" + rel,
-		"related": buildSelfLink(res, prepath) + "/" + rel,
+func buildRelationshipLinks(res Resource, prepath, rel string) map[string]interface{} {
+	return map[string]interface{}{
+		"self":    Link{HRef: buildSelfLink(res, prepath) + "/relationships/" + rel},
+		"related": Link{HRef: buildSelfLink(res, prepath) + "/" + rel},
 	}
 }

--- a/link.go
+++ b/link.go
@@ -31,8 +31,8 @@ func (l Link) MarshalJSON() ([]byte, error) {
 	return json.Marshal(l.HRef)
 }
 
-// A LinkHolder can hold and return meta values. It is useful for a struct that represents a resource type to implement
-// this interface to have a custom links as part of its JSON output.
+// A LinkHolder can hold and return meta values. It is useful for a struct that represents a
+// resource type to implement this interface to have a custom links as part of its JSON output.
 type LinkHolder interface {
 	Links() map[string]Link
 	SetLinks(map[string]Link)

--- a/link.go
+++ b/link.go
@@ -31,6 +31,13 @@ func (l Link) MarshalJSON() ([]byte, error) {
 	return json.Marshal(l.HRef)
 }
 
+// A LinkHolder can hold and return meta values. It is useful for a struct that represents a resource type to implement
+// this interface to have a custom links as part of its JSON output.
+type LinkHolder interface {
+	Links() map[string]Link
+	SetLinks(map[string]Link)
+}
+
 // buildSelfLink builds a URL that points to the resource represented by the
 // value v.
 //

--- a/soft_resource.go
+++ b/soft_resource.go
@@ -14,9 +14,10 @@ import (
 type SoftResource struct {
 	Type *Type
 
-	id   string
-	data map[string]interface{}
-	meta Meta
+	id    string
+	data  map[string]interface{}
+	meta  Meta
+	links map[string]Link
 }
 
 // Attrs returns the resource's attributes.
@@ -187,6 +188,16 @@ func (sr *SoftResource) Meta() Meta {
 // SetMeta sets the meta values of the resource.
 func (sr *SoftResource) SetMeta(m Meta) {
 	sr.meta = m
+}
+
+// Links returns the links of the resource.
+func (sr *SoftResource) Links() map[string]Link {
+	return sr.links
+}
+
+// SetLinks sets the links of the resource.
+func (sr *SoftResource) SetLinks(links map[string]Link) {
+	sr.links = links
 }
 
 func (sr *SoftResource) fields() []string {

--- a/soft_resource_test.go
+++ b/soft_resource_test.go
@@ -296,6 +296,25 @@ func TestSoftResourceMeta(t *testing.T) {
 	assert.Equal(meta, sr.Meta())
 }
 
+func TestSoftResource_Links(t *testing.T) {
+	assert := assert.New(t)
+	typ, _ := BuildType(mocktype{})
+	sr := &SoftResource{}
+	sr.Type = &typ
+	sr.SetID("id")
+
+	links := map[string]Link{
+		"link1": {HRef: "https://example.org/foo"},
+		"link2": {HRef: "https://example.org/bar", Meta: map[string]interface{}{
+			"key1": true,
+			"key2": "string",
+		}},
+	}
+
+	sr.SetLinks(links)
+	assert.Equal(links, sr.Links())
+}
+
 func TestSoftResourceGetSetID(t *testing.T) {
 	assert := assert.New(t)
 

--- a/testdata/goldenfiles/marshaling/collection_with_links.json
+++ b/testdata/goldenfiles/marshaling/collection_with_links.json
@@ -1,0 +1,151 @@
+{
+	"data": [
+		{
+			"attributes": {
+				"bool": true,
+				"int": 10,
+				"str": "str",
+				"time": "2013-06-24T22:03:34.8276Z",
+				"uint64": 1064
+			},
+			"id": "id1",
+			"links": {
+				"self": "https://example.org/mocktype/id1"
+			},
+			"relationships": {
+				"to-1": {
+					"data": {
+						"id": "id2",
+						"type": "mocktype"
+					},
+					"links": {
+						"related": "https://example.org/mocktype/id1/to-1",
+						"self": "https://example.org/mocktype/id1/relationships/to-1"
+					}
+				},
+				"to-x-from-1": {
+					"data": [
+						{
+							"id": "id4",
+							"type": "mocktype"
+						}
+					],
+					"links": {
+						"related": "https://example.org/mocktype/id1/to-x-from-1",
+						"self": "https://example.org/mocktype/id1/relationships/to-x-from-1"
+					}
+				}
+			},
+			"type": "mocktype"
+		},
+		{
+			"attributes": {
+				"bool": false,
+				"int": -42,
+				"str": "漢語",
+				"time": "0001-01-01T00:00:00Z",
+				"uint64": 0
+			},
+			"id": "id2",
+			"links": {
+				"self": "https://example.org/mocktype/id2"
+			},
+			"relationships": {
+				"to-1": {
+					"data": null,
+					"links": {
+						"related": "https://example.org/mocktype/id2/to-1",
+						"self": "https://example.org/mocktype/id2/relationships/to-1"
+					}
+				},
+				"to-x-from-1": {
+					"data": [],
+					"links": {
+						"related": "https://example.org/mocktype/id2/to-x-from-1",
+						"self": "https://example.org/mocktype/id2/relationships/to-x-from-1"
+					}
+				}
+			},
+			"type": "mocktype"
+		},
+		{
+			"attributes": {
+				"bool": false,
+				"int": 0,
+				"str": "",
+				"time": "0001-01-01T00:00:00Z",
+				"uint64": 0
+			},
+			"id": "id3",
+			"links": {
+				"self": "https://example.org/mocktype/id3"
+			},
+			"relationships": {
+				"to-1": {
+					"data": null,
+					"links": {
+						"related": "https://example.org/mocktype/id3/to-1",
+						"self": "https://example.org/mocktype/id3/relationships/to-1"
+					}
+				},
+				"to-x-from-1": {
+					"data": [],
+					"links": {
+						"related": "https://example.org/mocktype/id3/to-x-from-1",
+						"self": "https://example.org/mocktype/id3/relationships/to-x-from-1"
+					}
+				}
+			},
+			"type": "mocktype"
+		},
+		{
+			"attributes": {
+				"bool": false,
+				"int": 0,
+				"str": "",
+				"time": "0001-01-01T00:00:00Z",
+				"uint64": 0
+			},
+			"id": "id4",
+			"links": {
+				"self": "https://example.org/mocktype/id4"
+			},
+			"meta": {
+				"key1": "a string",
+				"key2": 42,
+				"key3": true,
+				"key4": "2013-06-24T22:03:34.8276Z"
+			},
+			"relationships": {
+				"to-1": {
+					"data": null,
+					"links": {
+						"related": "https://example.org/mocktype/id4/to-1",
+						"self": "https://example.org/mocktype/id4/relationships/to-1"
+					}
+				},
+				"to-x-from-1": {
+					"data": [],
+					"links": {
+						"related": "https://example.org/mocktype/id4/to-x-from-1",
+						"self": "https://example.org/mocktype/id4/relationships/to-x-from-1"
+					}
+				}
+			},
+			"type": "mocktype"
+		}
+	],
+	"jsonapi": {
+		"version": "1.0"
+	},
+	"links": {
+		"self": "https://example.org/fake/path?fields%5Bmocktype%5D=bool%2Cint%2Cstr%2Ctime%2Cto-1%2Cto-x-from-1%2Cuint64",
+		"foo": {
+			"href": "https://example.org/bar",
+			"meta": {
+				"foo": "bar",
+				"bar": "baz"
+			}
+		}
+	}
+}

--- a/testdata/goldenfiles/marshaling/empty_data_with_links.json
+++ b/testdata/goldenfiles/marshaling/empty_data_with_links.json
@@ -1,0 +1,16 @@
+{
+	"data": null,
+	"jsonapi": {
+		"version": "1.0"
+	},
+	"links": {
+		"self": "https://example.org/fake/path?fields%5Bmocktype%",
+		"foo": {
+			"href": "https://example.org/bar",
+			"meta": {
+				"last_accessed": "5 minutes ago"
+			}
+		},
+		"bar": "https://example.org/baz"
+	}
+}

--- a/testdata/goldenfiles/marshaling/resource_with_links.json
+++ b/testdata/goldenfiles/marshaling/resource_with_links.json
@@ -1,0 +1,65 @@
+{
+	"data": {
+		"attributes": {
+			"int": 12,
+			"str": "str"
+		},
+		"id": "id1",
+		"links": {
+			"self": "/mockTypeImpl/id1",
+			"test": "https://example.org/test"
+		},
+		"relationships": {
+			"to-1": {
+				"data": {
+					"id": "id5",
+					"type": "mockTypeImpl",
+					"meta": {
+						"k2": "v2"
+					}
+				},
+				"links": {
+					"related": "/mockTypeImpl/id1/to-1",
+					"self": "/mockTypeImpl/id1/relationships/to-1",
+					"l1": "https://example.org/l1"
+				},
+				"meta": {
+					"k1": "v1"
+				}
+			},
+			"to-x": {
+				"data": [
+                    {
+						"id": "id2",
+						"type": "mockTypeImpl"
+					},
+                    {
+						"id": "id3",
+						"type": "mockTypeImpl",
+						"meta": {
+							"key1": "value1"
+						}
+					}
+                ],
+				"links": {
+					"related": "/mockTypeImpl/id1/to-x",
+					"self": "/mockTypeImpl/id1/relationships/to-x",
+					"example": "https://example.org"
+				},
+				"meta": {
+					"test": "ok"
+				}
+			}
+		},
+		"meta": {
+			"foo": "bar"
+		},
+		"type": "mockTypeImpl"
+	},
+	"jsonapi": {
+		"version": "1.0"
+	},
+	"links": {
+		"self": "/fake/path?fields%5BmockTypeImpl%5D=int%2Cstr%2Cto-1%2Cto-x"
+	}
+}

--- a/type.go
+++ b/type.go
@@ -19,12 +19,12 @@ import (
 // even if it potentially can break existing code.
 //
 // The names are as follow:
-//  - string
-//  - int, int8, int16, int32, int64
-//  - uint, uint8, uint16, uint32, uint64
-//  - bool
-//  - time (Go type is time.Time)
-//  - bytes (Go type is []uint8 or []byte)
+//   - string
+//   - int, int8, int16, int32, int64
+//   - uint, uint8, uint16, uint32, uint64
+//   - bool
+//   - time (Go type is time.Time)
+//   - bytes (Go type is []uint8 or []byte)
 //
 // An asterisk is present as a prefix when the type is nullable (like *string).
 //


### PR DESCRIPTION
Currently, the ability to use Link members is somewhat limited and does not fully comply with the specification. The changes made in this PR fix this problem.

More about the implementation/details can be found [here](https://github.com/mfcochauxlaberge/jsonapi/issues/123#issuecomment-1179785450).